### PR TITLE
feat: feature selection + all preprocessing implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,22 @@ Built on [Polars](https://pola.rs) — works natively with DataFrames.
 
 | Component | Status |
 |---|---|
+| Component | Status |
+|---|---|---|
 | `StandardScaler` | ✅ |
-| `MinMaxScaler` | 🏗️ Stub |
-| `RobustScaler` | 🏗️ Stub |
-| `Normalizer` | 🏗️ Stub |
-| `OneHotEncoder` | 🏗️ Stub |
-| `LabelEncoder` | 🏗️ Stub |
-| `OrdinalEncoder` | 🏗️ Stub |
-| `Binarizer` | 🏗️ Stub |
-| `SimpleImputer` | 🏗️ Stub |
-| **`PolynomialFeatures`** | ✅ |
-| **`Pipeline`** | ✅ |
-| **`ColumnTransformer`** | ✅ |
+| `MinMaxScaler` | ✅ |
+| `RobustScaler` | ✅ |
+| `Normalizer` | ✅ |
+| `OneHotEncoder` | ✅ |
+| `LabelEncoder` | ✅ |
+| `OrdinalEncoder` | ✅ |
+| `Binarizer` | ✅ |
+| `SimpleImputer` | ✅ |
+| `PolynomialFeatures` | ✅ |
+| `Pipeline` | ✅ |
+| `ColumnTransformer` | ✅ |
+| `VarianceThreshold` | ✅ |
+| `SelectKBest` | ✅ |
 
 ## Usage
 
@@ -67,6 +71,24 @@ let ct = ColumnTransformer::new(
     vec![("scale".into(), Box::new(StandardScaler::new()), vec!["feat_a".into()])],
     Remainder::Passthrough,
 );
+```
+
+### Feature Selection
+
+```rust
+use featrs::feature_selection::VarianceThreshold;
+use featrs::feature_selection::SelectKBest;
+use featrs::feature_selection::select_kbest::FClassif;
+
+// Remove constant / low-variance features
+let mut vt = VarianceThreshold::new(0.01);
+vt.fit(features.clone(), target.clone())?;
+let filtered = vt.transform(features)?;
+
+// Select top k features by ANOVA F-value
+let mut skb = SelectKBest::new(5, Box::new(FClassif::new()));
+skb.fit(features.clone(), target)?;
+let selected = skb.transform(features)?;
 ```
 
 ### PolynomialFeatures

--- a/src/feature_selection/mod.rs
+++ b/src/feature_selection/mod.rs
@@ -1,0 +1,5 @@
+pub mod select_kbest;
+pub mod variance_threshold;
+
+pub use select_kbest::SelectKBest;
+pub use variance_threshold::VarianceThreshold;

--- a/src/feature_selection/select_kbest.rs
+++ b/src/feature_selection/select_kbest.rs
@@ -1,0 +1,205 @@
+use crate::traits::{Error, Fit, Result, Transform};
+use polars::prelude::*;
+
+/// Scoring function for SelectKBest.
+pub trait ScoreFunction: Send + Sync {
+    fn score(&self, x: &DataFrame, y: &Column) -> Result<Vec<(String, f64)>>;
+}
+
+/// ANOVA F-value between each feature and the target.
+///
+/// For each f64 column in X, computes F = (between-group variance) / (within-group variance).
+pub struct FClassif;
+
+impl FClassif {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for FClassif {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ScoreFunction for FClassif {
+    fn score(&self, x: &DataFrame, y: &Column) -> Result<Vec<(String, f64)>> {
+        let y_ca = y
+            .as_materialized_series()
+            .f64()
+            .map_err(|_| Error::InvalidInput("target must be f64".into()))?;
+        let y_vals: Vec<f64> = y_ca.iter().flatten().collect();
+        let n = y_vals.len() as f64;
+        let y_mean = y_vals.iter().sum::<f64>() / n;
+
+        // Determine unique classes
+        let mut classes: Vec<f64> = y_ca.iter().flatten().collect();
+        classes.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        classes.dedup();
+
+        let mut scores = Vec::new();
+
+        for col in x.columns() {
+            let name = col.name().to_string();
+            if col.dtype() != &DataType::Float64 {
+                continue;
+            }
+            let ca = col.f64().unwrap();
+            let vals: Vec<Option<f64>> = ca.iter().collect();
+
+            // Between-group sum of squares
+            let mut ss_between = 0.0;
+            // Within-group sum of squares
+            let mut ss_within = 0.0;
+
+            for &cls in &classes {
+                let group_vals: Vec<f64> = vals
+                    .iter()
+                    .zip(&y_vals)
+                    .filter_map(|(xv, &yv)| if (yv - cls).abs() < 1e-10 { *xv } else { None })
+                    .collect();
+
+                if group_vals.is_empty() {
+                    continue;
+                }
+                let g_mean = group_vals.iter().sum::<f64>() / group_vals.len() as f64;
+                let g_n = group_vals.len() as f64;
+
+                ss_between += g_n * (g_mean - y_mean).powi(2);
+
+                for &v in &group_vals {
+                    ss_within += (v - g_mean).powi(2);
+                }
+            }
+
+            let n_classes = classes.len() as f64;
+            let df_between = n_classes - 1.0;
+            let df_within = n - n_classes;
+
+            let f_stat = if ss_within > 1e-15 && df_within > 0.0 {
+                (ss_between / df_between) / (ss_within / df_within)
+            } else {
+                0.0
+            };
+
+            scores.push((name, f_stat));
+        }
+
+        Ok(scores)
+    }
+}
+
+/// Select top k features according to a scoring function.
+///
+/// Corresponds to `sklearn.feature_selection.SelectKBest`.
+pub struct SelectKBest {
+    fitted: bool,
+    k: usize,
+    score_fn: Box<dyn ScoreFunction>,
+    selected_columns: Option<Vec<String>>,
+    scores: Option<Vec<(String, f64)>>,
+}
+
+impl SelectKBest {
+    pub fn new(k: usize, score_fn: Box<dyn ScoreFunction>) -> Self {
+        Self {
+            fitted: false,
+            k,
+            score_fn,
+            selected_columns: None,
+            scores: None,
+        }
+    }
+
+    pub fn scores(&self) -> Option<&[(String, f64)]> {
+        self.scores.as_deref()
+    }
+}
+
+impl Fit<DataFrame, DataFrame> for SelectKBest {
+    type Output = ();
+
+    fn fit(&mut self, x: DataFrame, y: DataFrame) -> Result<()> {
+        if y.width() != 1 {
+            return Err(Error::InvalidInput(
+                "target must be a single-column DataFrame".into(),
+            ));
+        }
+        let y_col = &y.columns()[0];
+        let mut scores = self.score_fn.score(&x, y_col)?;
+
+        scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+
+        let k = self.k.min(scores.len());
+        let selected: Vec<String> = scores.iter().take(k).map(|(n, _)| n.clone()).collect();
+
+        self.scores = Some(scores);
+        self.selected_columns = Some(selected);
+        self.fitted = true;
+        Ok(())
+    }
+}
+
+impl Transform<DataFrame> for SelectKBest {
+    type Output = DataFrame;
+
+    fn transform(&self, x: DataFrame) -> Result<DataFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted("SelectKBest".into()));
+        }
+        let cols = self.selected_columns.as_ref().unwrap();
+        let refs: Vec<&str> = cols.iter().map(|s| s.as_str()).collect();
+        x.select(refs)
+            .map_err(|e| Error::Computation(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_features() -> DataFrame {
+        // 6 rows, 2 classes (0 and 1), 3 samples per class
+        // noise has weak class separation, signal has strong separation
+        let a = Column::from(Series::new(
+            "noise".into(),
+            &[1.0f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+        ));
+        let b = Column::from(Series::new(
+            "signal".into(),
+            &[0.0f64, 1.0, 2.0, 10.0, 11.0, 12.0],
+        ));
+        DataFrame::new(6, vec![a, b]).unwrap()
+    }
+
+    fn make_target_col() -> Column {
+        Column::from(Series::new(
+            "target".into(),
+            &[0.0f64, 0.0, 0.0, 1.0, 1.0, 1.0],
+        ))
+    }
+
+    #[test]
+    fn test_select_kbest_f_classif() {
+        let mut skb = SelectKBest::new(1, Box::new(FClassif::new()));
+        let features = make_features();
+        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
+
+        skb.fit(features.clone(), y).unwrap();
+        let result = skb.transform(features).unwrap();
+
+        assert_eq!(result.width(), 1);
+        assert_eq!(result.get_column_names()[0].as_str(), "signal");
+    }
+
+    #[test]
+    fn test_f_classif_scores() {
+        let f = FClassif::new();
+        let features = make_features();
+        let y_col = make_target_col();
+
+        let scores = f.score(&features, &y_col).unwrap();
+        assert_eq!(scores.len(), 2);
+    }
+}

--- a/src/feature_selection/variance_threshold.rs
+++ b/src/feature_selection/variance_threshold.rs
@@ -1,0 +1,114 @@
+use crate::traits::{Error, Fit, Result, Transform};
+use polars::prelude::*;
+
+/// Remove features with variance below a threshold.
+///
+/// Corresponds to `sklearn.feature_selection.VarianceThreshold`.
+pub struct VarianceThreshold {
+    fitted: bool,
+    threshold: f64,
+    selected_columns: Option<Vec<String>>,
+}
+
+impl VarianceThreshold {
+    pub fn new(threshold: f64) -> Self {
+        Self {
+            fitted: false,
+            threshold,
+            selected_columns: None,
+        }
+    }
+}
+
+impl Default for VarianceThreshold {
+    fn default() -> Self {
+        Self::new(0.0)
+    }
+}
+
+impl Fit<DataFrame, DataFrame> for VarianceThreshold {
+    type Output = ();
+
+    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+        if x.width() == 0 {
+            return Err(Error::InvalidInput("data has no columns".into()));
+        }
+
+        let mut selected = Vec::new();
+        for col in x.columns() {
+            let name = col.name().to_string();
+            let s = x.column(&name).unwrap();
+            if s.dtype() != &DataType::Float64 {
+                continue;
+            }
+            let ca = s.f64().unwrap();
+            let mean = ca.mean().unwrap_or(0.0);
+            let var =
+                ca.iter().flatten().map(|v| (v - mean).powi(2)).sum::<f64>() / ca.len() as f64;
+
+            if var >= self.threshold {
+                selected.push(name);
+            }
+        }
+
+        if selected.is_empty() {
+            return Err(Error::InvalidInput(
+                "no features meet the variance threshold".into(),
+            ));
+        }
+
+        self.selected_columns = Some(selected);
+        self.fitted = true;
+        Ok(())
+    }
+}
+
+impl Transform<DataFrame> for VarianceThreshold {
+    type Output = DataFrame;
+
+    fn transform(&self, x: DataFrame) -> Result<DataFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted("VarianceThreshold".into()));
+        }
+        let cols = self.selected_columns.as_ref().unwrap();
+        let refs: Vec<&str> = cols.iter().map(|s| s.as_str()).collect();
+        x.select(refs)
+            .map_err(|e| Error::Computation(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_df() -> DataFrame {
+        let a = Column::from(Series::new("low_var".into(), &[1.0f64, 1.0, 1.0]));
+        let b = Column::from(Series::new("high_var".into(), &[1.0f64, 5.0, 9.0]));
+        DataFrame::new(3, vec![a, b]).unwrap()
+    }
+
+    #[test]
+    fn test_variance_threshold_removes_low_var() {
+        let mut vt = VarianceThreshold::new(0.1);
+        let df = make_test_df();
+        let y = df.clone();
+
+        vt.fit(df.clone(), y).unwrap();
+        let result = vt.transform(df).unwrap();
+
+        assert_eq!(result.width(), 1);
+        assert_eq!(result.get_column_names()[0].as_str(), "high_var");
+    }
+
+    #[test]
+    fn test_variance_threshold_zero_keeps_all() {
+        let mut vt = VarianceThreshold::new(0.0);
+        let df = make_test_df();
+        let y = df.clone();
+
+        vt.fit(df.clone(), y).unwrap();
+        let result = vt.transform(df).unwrap();
+
+        assert_eq!(result.width(), 2);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod feature_selection;
 pub mod pipeline;
 pub mod preprocessing;
 pub mod traits;

--- a/src/preprocessing/binarizer.rs
+++ b/src/preprocessing/binarizer.rs
@@ -4,7 +4,6 @@ use polars::prelude::*;
 /// Binarize data (set feature values to 0 or 1) according to a threshold.
 ///
 /// Corresponds to `sklearn.preprocessing.Binarizer`.
-#[allow(dead_code)]
 pub struct Binarizer {
     fitted: bool,
     threshold: f64,
@@ -28,7 +27,10 @@ impl Default for Binarizer {
 impl Fit<DataFrame, DataFrame> for Binarizer {
     type Output = ();
 
-    fn fit(&mut self, _x: DataFrame, _y: DataFrame) -> Result<Self::Output> {
+    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+        if x.width() == 0 {
+            return Err(Error::InvalidInput("empty DataFrame".into()));
+        }
         self.fitted = true;
         Ok(())
     }
@@ -37,24 +39,89 @@ impl Fit<DataFrame, DataFrame> for Binarizer {
 impl Transform<DataFrame> for Binarizer {
     type Output = DataFrame;
 
-    fn transform(&self, _x: DataFrame) -> Result<Self::Output> {
-        Err(Error::NotFitted("Binarizer".into()))
+    fn transform(&self, x: DataFrame) -> Result<DataFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted("Binarizer".into()));
+        }
+
+        let col_names: Vec<String> = x
+            .get_column_names()
+            .iter()
+            .filter_map(|name| {
+                let col = x.column(name).ok()?;
+                if col.dtype() == &DataType::Float64 {
+                    Some(name.to_string())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let mut out = x.clone();
+
+        for name in &col_names {
+            let s = out.column(name.as_str()).unwrap();
+            let ca = s.f64().unwrap();
+            let binarized: ChunkedArray<Float64Type> = ca
+                .iter()
+                .map(|opt| opt.map(|v| if v > self.threshold { 1.0 } else { 0.0 }))
+                .collect();
+            out.replace(name.as_str(), binarized.into_series().into())
+                .unwrap();
+        }
+
+        Ok(out)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_binarizer_new() {
-        let b = Binarizer::new(0.5);
-        assert!(!b.fitted);
-    }
+    use approx::assert_relative_eq;
 
     #[test]
     fn test_binarizer_default() {
-        let b = Binarizer::default();
-        assert_eq!(b.threshold, 0.0);
+        let mut b = Binarizer::default();
+        let a = Column::from(Series::new("x".into(), &[-1.0f64, 0.0, 2.0]));
+        let df = DataFrame::new(3, vec![a]).unwrap();
+        let y = df.clone();
+
+        b.fit(df.clone(), y).unwrap();
+        let result = b.transform(df).unwrap();
+
+        let vals: Vec<f64> = result
+            .column("x")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .iter()
+            .flatten()
+            .collect();
+        assert_relative_eq!(vals[0], 0.0, epsilon = 1e-6);
+        assert_relative_eq!(vals[1], 0.0, epsilon = 1e-6);
+        assert_relative_eq!(vals[2], 1.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_binarizer_custom_threshold() {
+        let mut b = Binarizer::new(5.0);
+        let a = Column::from(Series::new("x".into(), &[1.0f64, 5.0, 10.0]));
+        let df = DataFrame::new(3, vec![a]).unwrap();
+        let y = df.clone();
+
+        b.fit(df.clone(), y).unwrap();
+        let result = b.transform(df).unwrap();
+
+        let vals: Vec<f64> = result
+            .column("x")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .iter()
+            .flatten()
+            .collect();
+        assert_relative_eq!(vals[0], 0.0, epsilon = 1e-6);
+        assert_relative_eq!(vals[1], 0.0, epsilon = 1e-6);
+        assert_relative_eq!(vals[2], 1.0, epsilon = 1e-6);
     }
 }

--- a/src/preprocessing/encoder.rs
+++ b/src/preprocessing/encoder.rs
@@ -1,13 +1,35 @@
+use crate::traits::{Error, Fit, Result, Transform};
+use polars::prelude::*;
 use std::collections::HashMap;
+
+fn column_unique_strings(col: &Column) -> Result<Vec<String>> {
+    let s = col.as_materialized_series();
+    let ca = s
+        .str()
+        .map_err(|e| Error::Computation(format!("column '{}' is not string: {}", col.name(), e)))?;
+    let mut unique: Vec<String> = ca
+        .iter()
+        .flatten()
+        .map(|s| s.to_string())
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+    unique.sort();
+    Ok(unique)
+}
 
 /// Encode categorical features as a one-hot numeric array.
 ///
 /// Corresponds to `sklearn.preprocessing.OneHotEncoder`.
-#[allow(dead_code)]
 pub struct OneHotEncoder {
     fitted: bool,
-    categories: Option<Vec<Vec<String>>>,
-    sparse_output: bool,
+    categories: Option<Vec<OneHotCategory>>,
+    drop_first: bool,
+}
+
+struct OneHotCategory {
+    column: String,
+    categories: Vec<String>,
 }
 
 impl OneHotEncoder {
@@ -15,8 +37,13 @@ impl OneHotEncoder {
         Self {
             fitted: false,
             categories: None,
-            sparse_output: false,
+            drop_first: false,
         }
+    }
+
+    pub fn drop_first(mut self, value: bool) -> Self {
+        self.drop_first = value;
+        self
     }
 }
 
@@ -26,10 +53,67 @@ impl Default for OneHotEncoder {
     }
 }
 
+impl Fit<DataFrame, DataFrame> for OneHotEncoder {
+    type Output = ();
+
+    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+        let mut cats = Vec::new();
+
+        for col in x.columns() {
+            let name = col.name().to_string();
+            let unique = column_unique_strings(col)?;
+
+            if !unique.is_empty() {
+                cats.push(OneHotCategory {
+                    column: name,
+                    categories: unique,
+                });
+            }
+        }
+
+        self.categories = Some(cats);
+        self.fitted = true;
+        Ok(())
+    }
+}
+
+impl Transform<DataFrame> for OneHotEncoder {
+    type Output = DataFrame;
+
+    fn transform(&self, x: DataFrame) -> Result<DataFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted("OneHotEncoder".into()));
+        }
+        let cats = self.categories.as_ref().unwrap();
+        let mut new_cols: Vec<Column> = Vec::new();
+        let n_rows = x.height();
+
+        for cat in cats {
+            let s = x.column(&cat.column).unwrap().as_materialized_series();
+            let ca = s.str().unwrap();
+            let start_idx = if self.drop_first { 1 } else { 0 };
+
+            for (_j, category) in cat.categories.iter().enumerate().skip(start_idx) {
+                let mut vals = vec![0.0f64; n_rows];
+                for (i, opt) in ca.iter().enumerate() {
+                    if let Some(v) = opt
+                        && v == *category
+                    {
+                        vals[i] = 1.0;
+                    }
+                }
+                let col_name = format!("{}_{}", cat.column, category);
+                new_cols.push(Column::from(Series::new(col_name.as_str().into(), &vals)));
+            }
+        }
+
+        DataFrame::new(n_rows, new_cols).map_err(|e| Error::Computation(e.to_string()))
+    }
+}
+
 /// Encode categorical labels with value between 0 and n_classes-1.
 ///
 /// Corresponds to `sklearn.preprocessing.LabelEncoder`.
-#[allow(dead_code)]
 pub struct LabelEncoder {
     fitted: bool,
     classes: Option<Vec<String>>,
@@ -52,13 +136,59 @@ impl Default for LabelEncoder {
     }
 }
 
+impl Fit<DataFrame, DataFrame> for LabelEncoder {
+    type Output = ();
+
+    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+        if x.width() != 1 {
+            return Err(Error::InvalidInput(
+                "LabelEncoder requires a single column".into(),
+            ));
+        }
+        let classes = column_unique_strings(&x.columns()[0])?;
+
+        let mapping: HashMap<String, usize> = classes
+            .iter()
+            .enumerate()
+            .map(|(i, c)| (c.clone(), i))
+            .collect();
+
+        self.classes = Some(classes);
+        self.mapping = Some(mapping);
+        self.fitted = true;
+        Ok(())
+    }
+}
+
+impl Transform<DataFrame> for LabelEncoder {
+    type Output = DataFrame;
+
+    fn transform(&self, x: DataFrame) -> Result<DataFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted("LabelEncoder".into()));
+        }
+        let mapping = self.mapping.as_ref().unwrap();
+        let s = x.columns()[0].as_materialized_series();
+        let ca = s.str().unwrap();
+
+        let encoded: ChunkedArray<UInt32Type> = ca
+            .iter()
+            .map(|opt| opt.and_then(|v| mapping.get(v).copied().map(|x| x as u32)))
+            .collect();
+
+        let mut series = encoded.into_series();
+        series.rename(s.name().clone());
+        DataFrame::new(x.height(), vec![Column::from(series)])
+            .map_err(|e| Error::Computation(e.to_string()))
+    }
+}
+
 /// Encode categorical features as an integer array.
 ///
 /// Corresponds to `sklearn.preprocessing.OrdinalEncoder`.
-#[allow(dead_code)]
 pub struct OrdinalEncoder {
     fitted: bool,
-    categories: Option<Vec<Vec<String>>>,
+    categories: Option<Vec<(String, HashMap<String, u32>)>>,
 }
 
 impl OrdinalEncoder {
@@ -76,25 +206,147 @@ impl Default for OrdinalEncoder {
     }
 }
 
+impl Fit<DataFrame, DataFrame> for OrdinalEncoder {
+    type Output = ();
+
+    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+        let mut cats = Vec::new();
+
+        for col in x.columns() {
+            let name = col.name().to_string();
+            let classes = column_unique_strings(col)?;
+
+            let mapping: HashMap<String, u32> = classes
+                .iter()
+                .enumerate()
+                .map(|(i, c)| (c.clone(), i as u32))
+                .collect();
+
+            cats.push((name, mapping));
+        }
+
+        self.categories = Some(cats);
+        self.fitted = true;
+        Ok(())
+    }
+}
+
+impl Transform<DataFrame> for OrdinalEncoder {
+    type Output = DataFrame;
+
+    fn transform(&self, x: DataFrame) -> Result<DataFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted("OrdinalEncoder".into()));
+        }
+        let mut out_cols = Vec::new();
+
+        for (name, mapping) in self.categories.as_ref().unwrap() {
+            let s = x.column(name.as_str()).unwrap().as_materialized_series();
+            let ca = s.str().unwrap();
+
+            let encoded: ChunkedArray<UInt32Type> = ca
+                .iter()
+                .map(|opt| opt.and_then(|v| mapping.get(v).copied()))
+                .collect();
+
+            let mut series = encoded.into_series();
+            series.rename(name.as_str().into());
+            out_cols.push(Column::from(series));
+        }
+
+        DataFrame::new(x.height(), out_cols).map_err(|e| Error::Computation(e.to_string()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_one_hot_encoder_new() {
-        let enc = OneHotEncoder::new();
-        assert!(!enc.fitted);
+    fn make_categorical_df() -> DataFrame {
+        let a = Column::from(Series::new(
+            "color".into(),
+            &["red", "blue", "red", "green"],
+        ));
+        let b = Column::from(Series::new("size".into(), &["S", "M", "L", "M"]));
+        DataFrame::new(4, vec![a, b]).unwrap()
     }
 
     #[test]
-    fn test_label_encoder_new() {
-        let enc = LabelEncoder::new();
-        assert!(!enc.fitted);
+    fn test_one_hot_encoder() {
+        let mut enc = OneHotEncoder::new();
+        let df = make_categorical_df();
+        let y = df.clone();
+
+        enc.fit(df.clone(), y).unwrap();
+        let result = enc.transform(df).unwrap();
+
+        assert_eq!(result.width(), 6);
+        assert_eq!(result.height(), 4);
     }
 
     #[test]
-    fn test_ordinal_encoder_new() {
-        let enc = OrdinalEncoder::new();
-        assert!(!enc.fitted);
+    fn test_one_hot_encoder_drop_first() {
+        let mut enc = OneHotEncoder::new().drop_first(true);
+        let df = make_categorical_df();
+        let y = df.clone();
+
+        enc.fit(df.clone(), y).unwrap();
+        let result = enc.transform(df).unwrap();
+
+        assert_eq!(result.width(), 4);
+    }
+
+    #[test]
+    fn test_label_encoder() {
+        let mut enc = LabelEncoder::new();
+        let colors = Column::from(Series::new(
+            "color".into(),
+            &["red", "blue", "red", "green"],
+        ));
+        let df = DataFrame::new(4, vec![colors]).unwrap();
+        let y = df.clone();
+
+        enc.fit(df.clone(), y).unwrap();
+        let result = enc.transform(df).unwrap();
+
+        let vals: Vec<u32> = result
+            .column("color")
+            .unwrap()
+            .u32()
+            .unwrap()
+            .iter()
+            .flatten()
+            .collect();
+        assert_eq!(vals, vec![2, 0, 2, 1]);
+    }
+
+    #[test]
+    fn test_ordinal_encoder() {
+        let mut enc = OrdinalEncoder::new();
+        let df = make_categorical_df();
+        let y = df.clone();
+
+        enc.fit(df.clone(), y).unwrap();
+        let result = enc.transform(df).unwrap();
+
+        let color_vals: Vec<u32> = result
+            .column("color")
+            .unwrap()
+            .u32()
+            .unwrap()
+            .iter()
+            .flatten()
+            .collect();
+        assert_eq!(color_vals, vec![2, 0, 2, 1]);
+
+        let size_vals: Vec<u32> = result
+            .column("size")
+            .unwrap()
+            .u32()
+            .unwrap()
+            .iter()
+            .flatten()
+            .collect();
+        assert_eq!(size_vals, vec![2, 1, 0, 1]);
     }
 }

--- a/src/preprocessing/imputer.rs
+++ b/src/preprocessing/imputer.rs
@@ -1,3 +1,7 @@
+use crate::traits::{Error, Fit, Result, Transform};
+use polars::prelude::*;
+use std::collections::HashMap;
+
 /// Imputation strategy.
 #[derive(Clone, Copy)]
 pub enum Strategy {
@@ -10,11 +14,10 @@ pub enum Strategy {
 /// Impute missing values using basic statistics.
 ///
 /// Corresponds to `sklearn.preprocessing.SimpleImputer`.
-#[allow(dead_code)]
 pub struct SimpleImputer {
     fitted: bool,
     strategy: Strategy,
-    fill_values: Option<Vec<f64>>,
+    fill_values: Option<HashMap<String, f64>>,
 }
 
 impl SimpleImputer {
@@ -43,19 +46,158 @@ impl SimpleImputer {
     }
 }
 
+impl Fit<DataFrame, DataFrame> for SimpleImputer {
+    type Output = ();
+
+    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+        let mut fill_values = HashMap::new();
+
+        for col in x.columns() {
+            let name = col.name().to_string();
+            if col.dtype() != &DataType::Float64 {
+                continue;
+            }
+            let ca = col.f64().unwrap();
+            let all_vals: Vec<f64> = ca.iter().flatten().collect();
+            let has_missing = ca.iter().any(|v| v.is_none());
+
+            if !has_missing {
+                continue;
+            }
+
+            let fill = match self.strategy {
+                Strategy::Mean => {
+                    if all_vals.is_empty() {
+                        return Err(Error::Computation(format!(
+                            "column '{}' has no non-null values",
+                            name
+                        )));
+                    }
+                    all_vals.iter().sum::<f64>() / all_vals.len() as f64
+                }
+                Strategy::Median => {
+                    let mut sorted = all_vals.clone();
+                    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+                    if sorted.is_empty() {
+                        return Err(Error::Computation(format!(
+                            "column '{}' has no non-null values",
+                            name
+                        )));
+                    }
+                    let mid = sorted.len() / 2;
+                    if sorted.len().is_multiple_of(2) {
+                        (sorted[mid - 1] + sorted[mid]) / 2.0
+                    } else {
+                        sorted[mid]
+                    }
+                }
+                Strategy::MostFrequent => {
+                    if all_vals.is_empty() {
+                        return Err(Error::Computation(format!(
+                            "column '{}' has no non-null values",
+                            name
+                        )));
+                    }
+                    let mut freq: HashMap<u64, usize> = HashMap::new();
+                    for &v in &all_vals {
+                        *freq.entry(v.to_bits()).or_default() += 1;
+                    }
+                    let (max_key, _) = freq.into_iter().max_by_key(|&(_, c)| c).unwrap();
+                    f64::from_bits(max_key)
+                }
+                Strategy::Constant(v) => v,
+            };
+
+            fill_values.insert(name, fill);
+        }
+
+        self.fill_values = Some(fill_values);
+        self.fitted = true;
+        Ok(())
+    }
+}
+
+impl Transform<DataFrame> for SimpleImputer {
+    type Output = DataFrame;
+
+    fn transform(&self, x: DataFrame) -> Result<DataFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted("SimpleImputer".into()));
+        }
+        let fill_values = self.fill_values.as_ref().unwrap();
+        let mut out = x.clone();
+
+        for (name, fill) in fill_values {
+            let s = out.column(name.as_str()).unwrap();
+            let ca = s.f64().unwrap();
+            let filled: ChunkedArray<Float64Type> =
+                ca.iter().map(|opt| opt.or(Some(*fill))).collect();
+            out.replace(name.as_str(), filled.into_series().into())
+                .unwrap();
+        }
+
+        Ok(out)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
 
-    #[test]
-    fn test_simple_imputer_new() {
-        let imp = SimpleImputer::mean();
-        assert!(matches!(imp.strategy, Strategy::Mean));
+    fn make_test_df() -> DataFrame {
+        let a = Column::from(Series::new("x".into(), &[Some(1.0f64), None, Some(3.0)]));
+        let b = Column::from(Series::new("y".into(), &[Some(10.0f64), Some(20.0), None]));
+        DataFrame::new(3, vec![a, b]).unwrap()
     }
 
     #[test]
-    fn test_simple_imputer_constant() {
-        let imp = SimpleImputer::constant(0.0);
-        assert!(matches!(imp.strategy, Strategy::Constant(v) if v == 0.0));
+    fn test_imputer_mean() {
+        let mut imp = SimpleImputer::mean();
+        let df = make_test_df();
+        let y = df.clone();
+
+        imp.fit(df.clone(), y).unwrap();
+        let result = imp.transform(df).unwrap();
+
+        let x_vals: Vec<f64> = result
+            .column("x")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .iter()
+            .flatten()
+            .collect();
+        assert_relative_eq!(x_vals[1], 2.0, epsilon = 1e-6); // (1+3)/2
+
+        let y_vals: Vec<f64> = result
+            .column("y")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .iter()
+            .flatten()
+            .collect();
+        assert_relative_eq!(y_vals[2], 15.0, epsilon = 1e-6); // (10+20)/2
+    }
+
+    #[test]
+    fn test_imputer_constant() {
+        let mut imp = SimpleImputer::constant(0.0);
+        let df = make_test_df();
+        let y = df.clone();
+
+        imp.fit(df.clone(), y).unwrap();
+        let result = imp.transform(df).unwrap();
+
+        let x_vals: Vec<f64> = result
+            .column("x")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .iter()
+            .flatten()
+            .collect();
+        assert_relative_eq!(x_vals[1], 0.0, epsilon = 1e-6);
     }
 }

--- a/src/preprocessing/normalizer.rs
+++ b/src/preprocessing/normalizer.rs
@@ -4,7 +4,6 @@ use polars::prelude::*;
 /// Normalize samples individually to unit norm.
 ///
 /// Corresponds to `sklearn.preprocessing.Normalizer`.
-#[allow(dead_code)]
 pub struct Normalizer {
     fitted: bool,
     norm: Norm,
@@ -36,12 +35,39 @@ impl Normalizer {
     pub fn max() -> Self {
         Self::new(Norm::Max)
     }
+
+    fn row_norm(values: &[f64], norm: Norm) -> f64 {
+        match norm {
+            Norm::L1 => values.iter().map(|v| v.abs()).sum(),
+            Norm::L2 => values.iter().map(|v| v * v).sum::<f64>().sqrt(),
+            Norm::Max => values.iter().cloned().fold(0.0f64, f64::max),
+        }
+    }
+}
+
+impl Default for Normalizer {
+    fn default() -> Self {
+        Self::l2()
+    }
 }
 
 impl Fit<DataFrame, DataFrame> for Normalizer {
     type Output = ();
 
-    fn fit(&mut self, _x: DataFrame, _y: DataFrame) -> Result<Self::Output> {
+    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+        if x.width() == 0 {
+            return Err(Error::InvalidInput("empty DataFrame".into()));
+        }
+        // Validate all columns are f64
+        for col in x.columns() {
+            if col.dtype() != &DataType::Float64 {
+                return Err(Error::InvalidInput(format!(
+                    "column '{}' is not f64",
+                    col.name()
+                )));
+            }
+        }
+        self.fitted = true;
         Ok(())
     }
 }
@@ -49,18 +75,105 @@ impl Fit<DataFrame, DataFrame> for Normalizer {
 impl Transform<DataFrame> for Normalizer {
     type Output = DataFrame;
 
-    fn transform(&self, _x: DataFrame) -> Result<Self::Output> {
-        Err(Error::NotFitted("Normalizer".into()))
+    fn transform(&self, x: DataFrame) -> Result<DataFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted("Normalizer".into()));
+        }
+
+        let n_cols = x.width();
+        let n_rows = x.height();
+        let mut out_cols: Vec<Column> = Vec::with_capacity(n_cols);
+
+        // Extract all columns as Vec<Vec<f64>>
+        let mut col_data: Vec<Vec<f64>> = Vec::with_capacity(n_cols);
+        let col_names: Vec<&str> = x.get_column_names().iter().map(|s| s.as_str()).collect();
+
+        for name in &col_names {
+            let ca = x.column(name).unwrap().f64().unwrap();
+            col_data.push(ca.iter().flatten().collect());
+        }
+
+        // Normalize each row
+        for i in 0..n_rows {
+            let row_vals: Vec<f64> = col_data.iter().map(|col| col[i]).collect();
+            let norm = Self::row_norm(&row_vals, self.norm);
+            if norm > f64::EPSILON {
+                for col in &mut col_data {
+                    col[i] /= norm;
+                }
+            }
+        }
+
+        // Rebuild columns
+        for (j, name) in col_names.iter().enumerate() {
+            let new_ca: ChunkedArray<Float64Type> =
+                ChunkedArray::from_slice(name.to_string().as_str().into(), &col_data[j]);
+            out_cols.push(new_ca.into_series().into());
+        }
+
+        DataFrame::new(n_rows, out_cols).map_err(|e| Error::Computation(e.to_string()))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+
+    fn make_test_df() -> DataFrame {
+        let a = Column::from(Series::new("a".into(), &[3.0f64, 0.0, 1.0]));
+        let b = Column::from(Series::new("b".into(), &[4.0f64, 0.0, 2.0]));
+        DataFrame::new(3, vec![a, b]).unwrap()
+    }
 
     #[test]
-    fn test_normalizer_new() {
-        let n = Normalizer::l2();
-        assert!(matches!(n.norm, Norm::L2));
+    fn test_l2_normalization() {
+        let mut n = Normalizer::l2();
+        let df = make_test_df();
+        let y = df.clone();
+
+        n.fit(df.clone(), y).unwrap();
+        let result = n.transform(df).unwrap();
+
+        // Row 0: [3,4] -> L2 norm = 5 -> [0.6, 0.8]
+        let col_a = result.column("a").unwrap().f64().unwrap();
+        let col_b = result.column("b").unwrap().f64().unwrap();
+        assert_relative_eq!(col_a.get(0).unwrap(), 0.6, epsilon = 1e-6);
+        assert_relative_eq!(col_b.get(0).unwrap(), 0.8, epsilon = 1e-6);
+
+        // Row 1: [0,0] stays [0,0]
+        assert_relative_eq!(col_a.get(1).unwrap(), 0.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_l1_normalization() {
+        let mut n = Normalizer::l1();
+        let df = make_test_df();
+        let y = df.clone();
+
+        n.fit(df.clone(), y).unwrap();
+        let result = n.transform(df).unwrap();
+
+        let col_a = result.column("a").unwrap().f64().unwrap();
+        let col_b = result.column("b").unwrap().f64().unwrap();
+        // Row 0: L1 norm = 7 -> [3/7, 4/7]
+        assert_relative_eq!(col_a.get(0).unwrap(), 3.0 / 7.0, epsilon = 1e-6);
+        assert_relative_eq!(col_b.get(0).unwrap(), 4.0 / 7.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_max_normalization() {
+        let mut n = Normalizer::max();
+        let df = make_test_df();
+        let y = df.clone();
+
+        n.fit(df.clone(), y).unwrap();
+        let result = n.transform(df).unwrap();
+
+        let col_a = result.column("a").unwrap().f64().unwrap();
+        let col_b = result.column("b").unwrap().f64().unwrap();
+        // Row 0: max = 4 -> [0.75, 1.0]
+        assert_relative_eq!(col_a.get(0).unwrap(), 0.75, epsilon = 1e-6);
+        assert_relative_eq!(col_b.get(0).unwrap(), 1.0, epsilon = 1e-6);
     }
 }

--- a/src/preprocessing/scaler.rs
+++ b/src/preprocessing/scaler.rs
@@ -1,19 +1,35 @@
 use polars::prelude::*;
-use std::collections::HashMap;
 
 use crate::traits::{Error, Fit, Result, Transform};
+
+fn numeric_f64_columns(df: &DataFrame) -> Vec<String> {
+    df.get_column_names()
+        .iter()
+        .filter_map(|name| {
+            if let Ok(s) = df.column(name) {
+                if s.dtype() == &DataType::Float64 {
+                    Some(name.to_string())
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .collect()
+}
 
 /// Standardize features by removing the mean and scaling to unit variance.
 ///
 /// Corresponds to `sklearn.preprocessing.StandardScaler`.
 pub struct StandardScaler {
     fitted: bool,
-    params: Option<Vec<ScalerParam>>,
+    params: Option<Vec<ScaleParam>>,
     with_mean: bool,
     with_std: bool,
 }
 
-struct ScalerParam {
+struct ScaleParam {
     name: String,
     mean: f64,
     std: f64,
@@ -38,23 +54,6 @@ impl StandardScaler {
         self.with_std = value;
         self
     }
-
-    fn numeric_f64_columns(&self, df: &DataFrame) -> Vec<String> {
-        df.get_column_names()
-            .iter()
-            .filter_map(|name| {
-                if let Ok(s) = df.column(name) {
-                    if s.dtype() == &DataType::Float64 {
-                        Some(name.to_string())
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
 }
 
 impl Default for StandardScaler {
@@ -66,12 +65,12 @@ impl Default for StandardScaler {
 impl Fit<DataFrame, DataFrame> for StandardScaler {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<Self::Output> {
+    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
         if x.height() == 0 || x.width() == 0 {
             return Err(Error::InvalidInput("data cannot be empty".into()));
         }
 
-        let col_names = self.numeric_f64_columns(&x);
+        let col_names = numeric_f64_columns(&x);
         if col_names.is_empty() {
             return Err(Error::InvalidInput(
                 "no f64 columns found in DataFrame".into(),
@@ -80,7 +79,7 @@ impl Fit<DataFrame, DataFrame> for StandardScaler {
 
         let mut params = Vec::with_capacity(col_names.len());
 
-        for name in col_names {
+        for name in &col_names {
             let s = x
                 .column(name.as_str())
                 .map_err(|e| Error::InvalidInput(format!("column '{}' not found: {}", name, e)))?;
@@ -114,7 +113,7 @@ impl Fit<DataFrame, DataFrame> for StandardScaler {
                 )));
             }
 
-            params.push(ScalerParam {
+            params.push(ScaleParam {
                 name: name.clone(),
                 mean: col_mean,
                 std: col_std,
@@ -153,30 +152,36 @@ impl Transform<DataFrame> for StandardScaler {
                 .map(|opt_v| opt_v.map(|v| (v - p.mean) / p.std))
                 .collect();
 
-            let new_s = scaled.into_series();
-            out.replace(&p.name, new_s.into()).map_err(|e| {
-                Error::Computation(format!("failed to replace column '{}': {}", p.name, e))
-            })?;
+            out.replace(&p.name, scaled.into_series().into())
+                .map_err(|e| {
+                    Error::Computation(format!("failed to replace column '{}': {}", p.name, e))
+                })?;
         }
 
         Ok(out)
     }
 }
 
-#[allow(dead_code)]
+/// Scale features to a given range (default [0, 1]).
+///
+/// Corresponds to `sklearn.preprocessing.MinMaxScaler`.
 pub struct MinMaxScaler {
     fitted: bool,
-    min: Option<HashMap<String, f64>>,
-    scale: Option<HashMap<String, f64>>,
+    params: Option<Vec<MinMaxParam>>,
     feature_range: (f64, f64),
+}
+
+struct MinMaxParam {
+    name: String,
+    min: f64,
+    scale: f64,
 }
 
 impl MinMaxScaler {
     pub fn new() -> Self {
         Self {
             fitted: false,
-            min: None,
-            scale: None,
+            params: None,
             feature_range: (0.0, 1.0),
         }
     }
@@ -193,25 +198,90 @@ impl Default for MinMaxScaler {
     }
 }
 
-#[allow(dead_code)]
+impl Fit<DataFrame, DataFrame> for MinMaxScaler {
+    type Output = ();
+
+    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+        let col_names = numeric_f64_columns(&x);
+        let r_min = self.feature_range.0;
+        let r_max = self.feature_range.1;
+        let mut params = Vec::new();
+
+        for name in &col_names {
+            let s = x.column(name.as_str()).unwrap();
+            let ca = s.f64().unwrap();
+            let vals: Vec<f64> = ca.iter().flatten().collect();
+            let col_min = vals.iter().cloned().fold(f64::NAN, f64::min);
+            let col_max = vals.iter().cloned().fold(f64::NAN, f64::max);
+
+            if (col_max - col_min).abs() < f64::EPSILON {
+                return Err(Error::Computation(format!(
+                    "column '{}' has constant values",
+                    name
+                )));
+            }
+
+            let scale = (r_max - r_min) / (col_max - col_min);
+            params.push(MinMaxParam {
+                name: name.clone(),
+                min: col_min,
+                scale,
+            });
+        }
+
+        self.params = Some(params);
+        self.fitted = true;
+        Ok(())
+    }
+}
+
+impl Transform<DataFrame> for MinMaxScaler {
+    type Output = DataFrame;
+
+    fn transform(&self, x: DataFrame) -> Result<DataFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted("MinMaxScaler".into()));
+        }
+        let r_min = self.feature_range.0;
+        let mut out = x.clone();
+
+        for p in self.params.as_ref().unwrap() {
+            let s = out.column(&p.name).unwrap();
+            let ca = s.f64().unwrap();
+            let scaled: ChunkedArray<Float64Type> = ca
+                .iter()
+                .map(|opt| opt.map(|v| (v - p.min) * p.scale + r_min))
+                .collect();
+            out.replace(&p.name, scaled.into_series().into()).unwrap();
+        }
+
+        Ok(out)
+    }
+}
+
+/// Scale features using statistics that are robust to outliers.
+///
+/// Corresponds to `sklearn.preprocessing.RobustScaler`.
 pub struct RobustScaler {
     fitted: bool,
-    center: Option<HashMap<String, f64>>,
-    scale: Option<HashMap<String, f64>>,
+    params: Option<Vec<RobustParam>>,
     with_centering: bool,
     with_scaling: bool,
-    quantile_range: (f64, f64),
+}
+
+struct RobustParam {
+    name: String,
+    center: f64,
+    scale: f64,
 }
 
 impl RobustScaler {
     pub fn new() -> Self {
         Self {
             fitted: false,
-            center: None,
-            scale: None,
+            params: None,
             with_centering: true,
             with_scaling: true,
-            quantile_range: (25.0, 75.0),
         }
     }
 
@@ -229,6 +299,83 @@ impl RobustScaler {
 impl Default for RobustScaler {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+fn percentile_sorted(sorted: &[f64], p: f64) -> f64 {
+    let n = sorted.len();
+    if n == 0 {
+        return 0.0;
+    }
+    let idx = (p / 100.0) * (n - 1) as f64;
+    let lo = idx.floor() as usize;
+    let hi = idx.ceil() as usize;
+    if lo == hi {
+        sorted[lo]
+    } else {
+        let frac = idx - lo as f64;
+        sorted[lo] * (1.0 - frac) + sorted[hi] * frac
+    }
+}
+
+impl Fit<DataFrame, DataFrame> for RobustScaler {
+    type Output = ();
+
+    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+        let col_names = numeric_f64_columns(&x);
+        let mut params = Vec::new();
+
+        for name in &col_names {
+            let s = x.column(name.as_str()).unwrap();
+            let ca = s.f64().unwrap();
+            let mut vals: Vec<f64> = ca.iter().flatten().collect();
+            vals.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+            let median = percentile_sorted(&vals, 50.0);
+            let q1 = percentile_sorted(&vals, 25.0);
+            let q3 = percentile_sorted(&vals, 75.0);
+            let iqr = q3 - q1;
+
+            if iqr < f64::EPSILON {
+                return Err(Error::Computation(format!(
+                    "column '{}' has zero IQR",
+                    name
+                )));
+            }
+
+            params.push(RobustParam {
+                name: name.clone(),
+                center: if self.with_centering { median } else { 0.0 },
+                scale: if self.with_scaling { iqr } else { 1.0 },
+            });
+        }
+
+        self.params = Some(params);
+        self.fitted = true;
+        Ok(())
+    }
+}
+
+impl Transform<DataFrame> for RobustScaler {
+    type Output = DataFrame;
+
+    fn transform(&self, x: DataFrame) -> Result<DataFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted("RobustScaler".into()));
+        }
+        let mut out = x.clone();
+
+        for p in self.params.as_ref().unwrap() {
+            let s = out.column(&p.name).unwrap();
+            let ca = s.f64().unwrap();
+            let scaled: ChunkedArray<Float64Type> = ca
+                .iter()
+                .map(|opt| opt.map(|v| (v - p.center) / p.scale))
+                .collect();
+            out.replace(&p.name, scaled.into_series().into()).unwrap();
+        }
+
+        Ok(out)
     }
 }
 
@@ -253,12 +400,56 @@ mod tests {
         let result = scaler.transform(df).unwrap();
 
         let scaled_a = result.column("a").unwrap().f64().unwrap();
-        let vals: Vec<f64> = scaled_a.iter().filter_map(|v| v).collect();
+        let vals: Vec<f64> = scaled_a.iter().flatten().collect();
 
-        assert_eq!(vals.len(), 3);
         assert_relative_eq!(vals[0], -1.22474487, epsilon = 1e-6);
         assert_relative_eq!(vals[1], 0.0, epsilon = 1e-6);
         assert_relative_eq!(vals[2], 1.22474487, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_min_max_scaler() {
+        let mut scaler = MinMaxScaler::new();
+        let df = make_test_df();
+        let y = df.clone();
+
+        scaler.fit(df.clone(), y).unwrap();
+        let result = scaler.transform(df).unwrap();
+
+        let vals: Vec<f64> = result
+            .column("a")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .iter()
+            .flatten()
+            .collect();
+        assert_relative_eq!(vals[0], 0.0, epsilon = 1e-6);
+        assert_relative_eq!(vals[1], 0.5, epsilon = 1e-6);
+        assert_relative_eq!(vals[2], 1.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_robust_scaler() {
+        let mut scaler = RobustScaler::new();
+        let df = make_test_df();
+        let y = df.clone();
+
+        scaler.fit(df.clone(), y).unwrap();
+        let result = scaler.transform(df).unwrap();
+
+        let vals: Vec<f64> = result
+            .column("a")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .iter()
+            .flatten()
+            .collect();
+        // median=3, IQR=2, so (1-3)/2=-1, (3-3)/2=0, (5-3)/2=1
+        assert_relative_eq!(vals[0], -1.0, epsilon = 1e-6);
+        assert_relative_eq!(vals[1], 0.0, epsilon = 1e-6);
+        assert_relative_eq!(vals[2], 1.0, epsilon = 1e-6);
     }
 
     #[test]
@@ -267,18 +458,5 @@ mod tests {
         let df = make_test_df();
         let result = scaler.transform(df);
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_min_max_scaler_new() {
-        let s = MinMaxScaler::new();
-        assert_eq!(s.feature_range, (0.0, 1.0));
-    }
-
-    #[test]
-    fn test_robust_scaler_new() {
-        let s = RobustScaler::new();
-        assert!(s.with_centering);
-        assert!(s.with_scaling);
     }
 }


### PR DESCRIPTION
Implements all remaining stubs and adds feature selection.

### New: Feature Selection

- **VarianceThreshold** — remove features with variance below a threshold
- **SelectKBest** — select top k features with `FClassif` (ANOVA F-value)
- Extensible `ScoreFunction` trait for custom scoring functions

### Now Implemented (previously stubs)

- **MinMaxScaler** — scale to `[0,1]` or custom range
- **RobustScaler** — robust scaling using median + IQR
- **Normalizer** — L1, L2, Max row-wise normalization
- **Binarizer** — threshold binarization
- **SimpleImputer** — mean, median, most_frequent, constant
- **OneHotEncoder** — dummy coding with `drop_first` option
- **LabelEncoder** — label to `0..n-1` integer mapping
- **OrdinalEncoder** — per-column category to integer mapping

### Tests

25 tests passing, clippy clean, fmt clean. All preprocessing modules now have real implementations.
