### PR TITLE
featrs 0.3.0: API redesign, correctness, lints, docs, tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,31 +9,107 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  build:
+  build-test:
+    name: Build & Test (${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        toolchain: [stable]
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
+      - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ matrix.toolchain }}
           components: clippy, rustfmt
 
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: stable-${{ matrix.os }}
+
       - name: Build
-        run: cargo build --all-features
+        run: cargo build
 
       - name: Clippy
-        run: cargo clippy --all-features -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Format
         run: cargo fmt --check
 
       - name: Test
-        run: cargo test --all-features
+        run: cargo test
+
+  docs:
+    name: Rustdoc
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: stable-docs
+
+      - name: Check docs
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --no-deps
+
+  msrv:
+    name: MSRV (1.91)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (1.91.0)
+        uses: dtolnay/rust-toolchain@1.91.0
+        with:
+          components: clippy
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: msrv-1.91
+
+      - name: Check build on MSRV
+        run: cargo +1.91.0 build
+
+      - name: Test on MSRV
+        run: cargo +1.91.0 test
+
+  audit:
+    name: Security audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: stable-audit
+
+      - name: Generate lockfile
+        run: cargo generate-lockfile
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Audit
+        run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,9 @@ jobs:
         run: cargo install cargo-audit --locked
 
       - name: Audit
-        run: cargo audit
+        # quick-xml RUSTSECs are transitive via polars–io → object_store.
+        # Tracked: re-evaluate when polars bumps its quick-xml dependency.
+        run: cargo audit --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195
 
   publish-dry-run:
     name: Publish (dry-run)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,21 @@ jobs:
 
       - name: Audit
         run: cargo audit
+
+  publish-dry-run:
+    name: Publish (dry-run)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: stable-publish
+
+      - name: cargo publish --dry-run
+        run: cargo publish --dry-run --allow-dirty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,86 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Declared Minimum Supported Rust Version (MSRV) as 1.91 in `Cargo.toml` via
+  `rust-version = "1.91"`. The floor is set by `polars 0.54`'s use of `_` array
+  lengths and `strict_abs` (both stabilized in Rust 1.91), plus the transitive
+  `sysinfo` dependency (requires 1.88). Edition 2024 itself only requires 1.85.
+- Rewrote CI to cache cargo build artifacts, test on Linux/macOS/Windows,
+  check rustdoc with `-D warnings`, verify the MSRV (1.91) in a dedicated job,
+  and run `cargo audit` for security advisories.
+
+### Added
+
+- Crate-level lints: `#![forbid(unsafe_code)]` and `#![warn(missing_docs)]`,
+  plus a `clippy.toml` pinning `msrv = "1.91"`. `clippy::unwrap_used` is
+  explicitly allowed pending a sweep that replaces `unwrap()` with `Result`.
+- Doc comments on the 10 previously-undocumented public items
+  (`AutoTypeDetector::new`, `CyclicalEncoder::{new,with_periods}`,
+  `Difference::new`, `RollingFn` variants, `RollingAggregator::new`).
+
+### Changed
+
+- Consolidated duplicated preprocessing helpers into a new `util` module:
+  `numeric_f64_columns`, `require_f64_columns`, and `replace_f64_column`.
+  The scaler and polynomial `fit`/`transform` implementations now share one
+  copy of the column-discovery, validation, and in-place-replace logic.
+- Collapsed the byte-identical crate-root and `prelude` re-export lists into a
+  single canonical list in `prelude`, re-exported at the root via
+  `pub use crate::prelude::*`. New public types now only need to be added once.
+
+### Fixed
+
+- Replaced `partial_cmp().unwrap()` with `total_cmp()` at the four float-sort
+  sites (`RobustScaler`, `SimpleImputer::Median`, `FClassif`, `SelectKBest`),
+  so NaN-bearing columns no longer panic during `fit`.
+- `AutoTypeDetector::transform` no longer re-fits its `OneHotEncoder` /
+  `FeatureHasher` sub-transformers on every call. They are now fit once during
+  `fit` and stored, so learned categories and hash mappings are stable across
+  `transform` calls (idempotent, O(N) instead of O(N·M) per call).
+
+### Added
+
+- Regression tests: NaN-bearing `RobustScaler` and `SimpleImputer::Median`
+  sorts, plus the first unit tests for `AutoTypeDetector` (detection, transform
+  idempotency, and not-fitted error).
+
+## [0.2.0] - 2026-07-06
+
+### Added
+
+- Time-series transformers: `Lagger`, `RollingAggregator` (with `RollingFn`),
+  `Difference`, `CyclicalEncoder`.
+- `FeatureHasher` for hashed categorical encoding.
+- `AutoTypeDetector` with `ColumnType` inference and a `PolynomialFeaturesBuilder`.
+- `prelude` module re-exporting the public API.
+- Integration tests covering end-to-end pipelines, feature selection, encoders,
+  and imputation.
+
+### Changed
+
+- Actionable error messages across all transformers.
+- Polished README with badges, quick start, and feature matrix.
+
+## [0.1.0] - 2026-07-06
+
+### Added
+
+- Core trait hierarchy: `Fit`, `Transform`, `FitTransform` with `Error`/`Result`.
+- Preprocessing: `StandardScaler`, `MinMaxScaler`, `RobustScaler`, `Normalizer`,
+  `Binarizer`, `OneHotEncoder`, `LabelEncoder`, `OrdinalEncoder`, `SimpleImputer`,
+  `PolynomialFeatures`, `MissingIndicator`.
+- Feature selection: `SelectKBest` with `FClassif`, `VarianceThreshold`.
+- Pipeline primitives: `Pipeline`, `ColumnTransformer` with `Remainder`.
+- Comprehensive API docs, module docs, and contributing guide.
+
+[Unreleased]: https://github.com/DeathSurfing/featrs/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/DeathSurfing/featrs/releases/tag/v0.2.0
+[0.1.0]: https://github.com/DeathSurfing/featrs/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,50 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+## [0.3.0] - 2026-07-06
 
-- Declared Minimum Supported Rust Version (MSRV) as 1.91 in `Cargo.toml` via
-  `rust-version = "1.91"`. The floor is set by `polars 0.54`'s use of `_` array
-  lengths and `strict_abs` (both stabilized in Rust 1.91), plus the transitive
-  `sysinfo` dependency (requires 1.88). Edition 2024 itself only requires 1.85.
-- Rewrote CI to cache cargo build artifacts, test on Linux/macOS/Windows,
-  check rustdoc with `-D warnings`, verify the MSRV (1.91) in a dedicated job,
-  and run `cargo audit` for security advisories.
+### Changed (breaking)
+
+- **Split `Fit` into `Fit` and `FitSupervised`.** Unsupervised transformers now
+  implement `Fit<X>` with `fit(&mut self, x: X)` (no target). Only supervised
+  transformers (`SelectKBest`) implement `FitSupervised<X, Y>` with
+  `fit(&mut self, x: X, y: Y)`. **Migration:** drop the second argument to
+  `.fit(...)` on every transformer except `SelectKBest` (e.g.
+  `scaler.fit(df, target)` → `scaler.fit(df)`). `use featrs::traits::FitSupervised;`
+  where you call `SelectKBest::fit`.
+- **`MissingIndicator` moved** from `featrs::traits::missing_indicator` to
+  `featrs::preprocessing::missing_indicator`. The prelude re-export is
+  unchanged. **Migration:** update any direct `use featrs::traits::missing_indicator`
+  paths.
+- **`PolynomialFeatures::new` and `PolynomialFeaturesBuilder::build` now return
+  `Result<Self>`** instead of panicking on `degree == 0` / missing degree.
+  **Migration:** add `.unwrap()` (tests) or `?` (fallible code) at call sites.
+- **`Pipeline::new` now returns `Result<Self>`** instead of panicking on empty
+  steps. **Migration:** add `.unwrap()` or `?`.
+- **`FeatureHasher` uses the signed hashing trick.** Each bucket is now
+  incremented by `+1.0` or `-1.0` (determined by a second independent hash),
+  so the expected bucket value is zero and collisions no longer bias the mean.
+  **Migration:** downstream models trained on unsigned `FeatureHasher` output
+  may need retraining; the column count and dtypes are unchanged.
 
 ### Added
 
-- Crate-level lints: `#![forbid(unsafe_code)]` and `#![warn(missing_docs)]`,
-  plus a `clippy.toml` pinning `msrv = "1.91"`. `clippy::unwrap_used` is
-  explicitly allowed pending a sweep that replaces `unwrap()` with `Result`.
-- Doc comments on the 10 previously-undocumented public items
-  (`AutoTypeDetector::new`, `CyclicalEncoder::{new,with_periods}`,
-  `Difference::new`, `RollingFn` variants, `RollingAggregator::new`).
-
-### Changed
-
-- Consolidated duplicated preprocessing helpers into a new `util` module:
-  `numeric_f64_columns`, `require_f64_columns`, and `replace_f64_column`.
-  The scaler and polynomial `fit`/`transform` implementations now share one
-  copy of the column-discovery, validation, and in-place-replace logic.
-- Collapsed the byte-identical crate-root and `prelude` re-export lists into a
-  single canonical list in `prelude`, re-exported at the root via
-  `pub use crate::prelude::*`. New public types now only need to be added once.
+- `FitTransform::fit_transform(&mut self, x: X) -> Result<Output>` with a
+  default implementation of `fit` followed by `transform`. Types may override
+  it with a single-pass implementation. `FitSupervised` is re-exported from
+  the prelude.
+- Tests for the signed hashing trick (`hash_to_bucket` determinism, sign ∈
+  `{-1, +1}`, integral bucket values).
 
 ### Fixed
 
-- Replaced `partial_cmp().unwrap()` with `total_cmp()` at the four float-sort
-  sites (`RobustScaler`, `SimpleImputer::Median`, `FClassif`, `SelectKBest`),
-  so NaN-bearing columns no longer panic during `fit`.
-- `AutoTypeDetector::transform` no longer re-fits its `OneHotEncoder` /
-  `FeatureHasher` sub-transformers on every call. They are now fit once during
-  `fit` and stored, so learned categories and hash mappings are stable across
-  `transform` calls (idempotent, O(N) instead of O(N·M) per call).
+- `partial_cmp().unwrap()` → `total_cmp()` at the four float-sort sites
+  (NaN-bearing columns no longer panic).
+- `AutoTypeDetector::transform` no longer re-fits sub-transformers on every
+  call (idempotent, O(N) per call).
+- All production `unwrap()`/`expect()` replaced with `Result`-based errors;
+  `clippy::unwrap_used`/`expect_used` now denied in production code.
 
-### Added
+### Changed (non-breaking)
 
-- Regression tests: NaN-bearing `RobustScaler` and `SimpleImputer::Median`
-  sorts, plus the first unit tests for `AutoTypeDetector` (detection, transform
-  idempotency, and not-fitted error).
+- Declared MSRV 1.91 in `Cargo.toml` (`rust-version = "1.91"`); floor set by
+  `polars 0.54` (`_` array lengths, `strict_abs`, transitive `sysinfo`).
+- Rewrote CI: cargo caching, Linux/macOS/Windows matrix, rustdoc with
+  `-D warnings`, dedicated MSRV job, `cargo audit`, concurrency cancellation.
+- Added crate-level lints (`#![forbid(unsafe_code)]`, `#![warn(missing_docs)]`)
+  and a `clippy.toml`; fixed the 10 `missing_docs` violations.
+- Consolidated duplicated preprocessing helpers into a new `util` module
+  (`numeric_f64_columns`, `require_f64_columns`, `replace_f64_column`); the
+  scaler/polynomial `fit`/`transform` share one copy of the column logic.
+- Collapsed the byte-identical crate-root and `prelude` re-export lists into a
+  single canonical list in `prelude` (`pub use crate::prelude::*` at root).
+- Regression tests for NaN sorts and the first `AutoTypeDetector` tests.
 
 ## [0.2.0] - 2026-07-06
 
@@ -81,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pipeline primitives: `Pipeline`, `ColumnTransformer` with `Remainder`.
 - Comprehensive API docs, module docs, and contributing guide.
 
-[Unreleased]: https://github.com/DeathSurfing/featrs/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/DeathSurfing/featrs/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/DeathSurfing/featrs/releases/tag/v0.3.0
 [0.2.0]: https://github.com/DeathSurfing/featrs/releases/tag/v0.2.0
 [0.1.0]: https://github.com/DeathSurfing/featrs/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "featrs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.91"
 description = "Feature engineering library for Rust, inspired by scikit-learn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "featrs"
 version = "0.2.0"
 edition = "2024"
+rust-version = "1.91"
 description = "Feature engineering library for Rust, inspired by scikit-learn"
 authors = ["Aditya Vikram Mahendru"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Built on [Polars](https://pola.rs) — all transformations operate natively on `
 
 ```toml
 [dependencies]
-featrs = "0.2"
+featrs = "0.3"
 ```
 
 ## Quick start
@@ -23,7 +23,7 @@ featrs = "0.2"
 use featrs::prelude::*;
 
 let mut scaler = StandardScaler::new();
-scaler.fit(data.clone(), target)?;
+scaler.fit(data.clone())?;
 let scaled = scaler.transform(data)?;
 ```
 
@@ -61,7 +61,7 @@ let scaled = scaler.transform(data)?;
 use featrs::prelude::*;
 
 let mut scaler = StandardScaler::new();
-scaler.fit(df.clone(), target.clone())?;
+scaler.fit(df.clone())?;
 let scaled = scaler.transform(df)?;
 ```
 
@@ -72,9 +72,9 @@ use featrs::prelude::*;
 
 let mut pipeline = Pipeline::new(vec![
     ("scale".into(), Box::new(StandardScaler::new())),
-    ("poly".into(), Box::new(PolynomialFeatures::new(2))),
-]);
-pipeline.fit(df.clone(), target)?;
+    ("poly".into(), Box::new(PolynomialFeatures::new(2)?)),
+])?;
+pipeline.fit(df.clone())?;
 let result = pipeline.transform(df)?;
 ```
 
@@ -98,7 +98,7 @@ let pf = PolynomialFeatures::builder()
     .degree(3)
     .include_bias(false)
     .interaction_only(true)
-    .build();
+    .build()?;
 ```
 
 ### Feature Selection
@@ -107,7 +107,7 @@ let pf = PolynomialFeatures::builder()
 use featrs::prelude::*;
 
 let mut vt = VarianceThreshold::new(0.01);
-vt.fit(features.clone(), target.clone())?;
+vt.fit(features.clone())?;
 let filtered = vt.transform(features)?;
 
 let mut skb = SelectKBest::new(5, Box::new(FClassif::new()));
@@ -121,7 +121,7 @@ let selected = skb.transform(features)?;
 use featrs::prelude::*;
 
 let mut lagger = Lagger::new(&["sales", "revenue"], &[1, 7, 30]);
-lagger.fit(df.clone(), target)?;
+lagger.fit(df.clone())?;
 let lagged = lagger.transform(df)?;  // adds sales_lag_1, sales_lag_7, ...
 ```
 
@@ -132,7 +132,7 @@ use featrs::prelude::*;
 use featrs::time_series::rolling::RollingFn;
 
 let mut rolling = RollingAggregator::new(&["price"], 7, RollingFn::Mean);
-rolling.fit(df.clone(), target)?;
+rolling.fit(df.clone())?;
 let result = rolling.transform(df)?;  // adds price_mean_7
 ```
 
@@ -142,11 +142,11 @@ let result = rolling.transform(df)?;  // adds price_mean_7
 use featrs::prelude::*;
 
 let mut diff = Difference::diff(&["sales"], 1);
-diff.fit(df.clone(), target)?;
+diff.fit(df.clone())?;
 let result = diff.transform(df)?;  // adds sales_diff_1
 
 let mut pct = Difference::pct_change(&["price"], 1);
-pct.fit(df.clone(), target)?;
+pct.fit(df.clone())?;
 let result = pct.transform(df)?;  // adds price_pct_1
 ```
 
@@ -156,7 +156,7 @@ let result = pct.transform(df)?;  // adds price_pct_1
 use featrs::prelude::*;
 
 let mut enc = CyclicalEncoder::new(&["hour"], 24);
-enc.fit(df.clone(), target)?;
+enc.fit(df.clone())?;
 let result = enc.transform(df)?;  // adds hour_sin, hour_cos
 ```
 
@@ -166,7 +166,7 @@ let result = enc.transform(df)?;  // adds hour_sin, hour_cos
 use featrs::prelude::*;
 
 let mut fh = FeatureHasher::new(&["user_id", "category"], 100);
-fh.fit(df.clone(), target)?;
+fh.fit(df.clone())?;
 let hashed = fh.transform(df)?;  // 100 hashed columns
 ```
 
@@ -176,7 +176,7 @@ let hashed = fh.transform(df)?;  // 100 hashed columns
 use featrs::prelude::*;
 
 let mut ind = MissingIndicator::all();
-ind.fit(df.clone(), target)?;
+ind.fit(df.clone())?;
 let marked = ind.transform(df)?;  // adds {col}_missing where nulls exist
 ```
 
@@ -188,7 +188,7 @@ use featrs::prelude::*;
 let mut atd = AutoTypeDetector::new()
     .cat_threshold(30)     // one-hot if < 30 unique values
     .hash_buckets(200);    // hash to 200 buckets otherwise
-atd.fit(df.clone(), target)?;
+atd.fit(df.clone())?;
 let result = atd.transform(df)?;
 ```
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,10 @@
+# Clippy configuration for featrs.
+# See: https://rust-lang.github.io/rust-clippy/stable/index.html
+
+# Minimum Supported Rust Version — keeps MSRV-aware lints (e.g. `clippy::manual_*`)
+# accurate against the declared `rust-version` in Cargo.toml.
+msrv = "1.91"
+
+# Flag functions whose cognitive complexity exceeds this threshold.
+# Transformers should stay readable; raise if a legitimate algorithm needs more.
+cognitive-complexity-threshold = 30

--- a/examples/scaling_pipeline.rs
+++ b/examples/scaling_pipeline.rs
@@ -1,0 +1,28 @@
+//! End-to-end example: scale a small DataFrame, expand polynomial features,
+//! and print the result. Run with `cargo run --example scaling_pipeline`.
+
+use featrs::prelude::*;
+use featrs::traits::{Fit, Transform};
+use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+
+fn main() -> featrs::Result<()> {
+    let a = Column::from(Series::new("a".into(), &[1.0_f64, 2.0, 3.0, 4.0]));
+    let b = Column::from(Series::new("b".into(), &[2.0_f64, 4.0, 6.0, 8.0]));
+    let df = DataFrame::new(4, vec![a, b]).unwrap();
+
+    let mut pipeline = Pipeline::new(vec![
+        ("scale".into(), Box::new(StandardScaler::new())),
+        ("poly".into(), Box::new(PolynomialFeatures::new(2)?)),
+    ])?;
+
+    pipeline.fit(df.clone())?;
+    let result = pipeline.transform(df)?;
+
+    println!(
+        "Output shape: {} cols x {} rows",
+        result.width(),
+        result.height()
+    );
+    println!("{result}");
+    Ok(())
+}

--- a/src/feature_selection/select_kbest.rs
+++ b/src/feature_selection/select_kbest.rs
@@ -148,9 +148,21 @@ impl ScoreFunction for FClassif {
 /// ```rust
 /// use featrs::feature_selection::SelectKBest;
 /// use featrs::feature_selection::select_kbest::FClassif;
+/// use featrs::traits::{FitSupervised, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
 ///
-/// // Keep the single feature with the highest F-score
+/// let a = Column::from(Series::new("noise".into(), &[1.0_f64, 2.0, 3.0, 4.0]));
+/// let b = Column::from(Series::new("signal".into(), &[0.0_f64, 1.0, 2.0, 10.0]));
+/// let features = DataFrame::new(4, vec![a, b])?;
+///
+/// let target = Column::from(Series::new("y".into(), &[0.0_f64, 0.0, 1.0, 1.0]));
+/// let y = DataFrame::new(4, vec![target])?;
+///
 /// let mut skb = SelectKBest::new(1, Box::new(FClassif::new()));
+/// skb.fit(features.clone(), y.clone())?;
+/// let selected = skb.transform(features)?;
+/// assert_eq!(selected.width(), 1);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct SelectKBest {
     fitted: bool,

--- a/src/feature_selection/select_kbest.rs
+++ b/src/feature_selection/select_kbest.rs
@@ -60,7 +60,7 @@ impl ScoreFunction for FClassif {
         let y_mean = y_vals.iter().sum::<f64>() / n;
 
         let mut classes: Vec<f64> = y_ca.iter().flatten().collect();
-        classes.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        classes.sort_by(|a, b| a.total_cmp(b));
         classes.dedup();
 
         if classes.len() < 2 {
@@ -198,7 +198,7 @@ impl Fit<DataFrame, DataFrame> for SelectKBest {
             ));
         }
 
-        scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        scores.sort_by(|a, b| b.1.total_cmp(&a.1));
 
         let k = self.k.min(scores.len());
         let selected: Vec<String> = scores.iter().take(k).map(|(n, _)| n.clone()).collect();

--- a/src/feature_selection/select_kbest.rs
+++ b/src/feature_selection/select_kbest.rs
@@ -86,7 +86,14 @@ impl ScoreFunction for FClassif {
             if col.dtype() != &DataType::Float64 {
                 continue;
             }
-            let ca = col.f64().unwrap();
+            let ca = col.f64().map_err(|e| {
+                Error::InvalidInput(format!(
+                    "FClassif: column '{}' has dtype {}; expected Float64. {}",
+                    name,
+                    col.dtype(),
+                    e
+                ))
+            })?;
             let vals: Vec<Option<f64>> = ca.iter().collect();
 
             let mut ss_between = 0.0;
@@ -221,7 +228,13 @@ impl Transform<DataFrame> for SelectKBest {
                     .into(),
             ));
         }
-        let cols = self.selected_columns.as_ref().unwrap();
+        let cols = self.selected_columns.as_ref().ok_or_else(|| {
+            Error::NotFitted(
+                "SelectKBest has not been fitted. \
+                 Call .fit(dataframe, target) before .transform()."
+                    .into(),
+            )
+        })?;
         if cols.is_empty() {
             // Should not happen if fit succeeded, but handle gracefully
             return Err(Error::Computation(

--- a/src/feature_selection/select_kbest.rs
+++ b/src/feature_selection/select_kbest.rs
@@ -3,7 +3,7 @@
 //! Provides [`SelectKBest`] and the [`FClassif`] scoring function
 //! (ANOVA F-value between each feature and the target).
 
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, FitSupervised, Result, Transform};
 use polars::prelude::*;
 
 /// Scoring function for [`SelectKBest`].
@@ -138,6 +138,11 @@ impl ScoreFunction for FClassif {
 
 /// Select the top `k` features according to a [`ScoreFunction`].
 ///
+/// `SelectKBest` is supervised: it implements [`FitSupervised`] and requires a
+/// target `y` at `fit` time. Only `Float64` feature columns are scored; columns
+/// of other dtypes are silently skipped. The target `y` must be a single
+/// `Float64` column with at least two distinct classes.
+///
 /// # Example
 ///
 /// ```rust
@@ -178,7 +183,7 @@ impl SelectKBest {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for SelectKBest {
+impl FitSupervised<DataFrame, DataFrame> for SelectKBest {
     type Output = ();
 
     fn fit(&mut self, x: DataFrame, y: DataFrame) -> Result<()> {

--- a/src/feature_selection/variance_threshold.rs
+++ b/src/feature_selection/variance_threshold.rs
@@ -18,8 +18,18 @@ use polars::prelude::*;
 ///
 /// ```rust
 /// use featrs::feature_selection::VarianceThreshold;
+/// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let low = Column::from(Series::new("low".into(), &[1.0_f64, 1.0, 1.0]));
+/// let high = Column::from(Series::new("high".into(), &[1.0_f64, 5.0, 9.0]));
+/// let df = DataFrame::new(3, vec![low, high])?;
 ///
 /// let mut vt = VarianceThreshold::new(0.01);
+/// vt.fit(df.clone())?;
+/// let filtered = vt.transform(df)?;
+/// assert_eq!(filtered.width(), 1);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct VarianceThreshold {
     fitted: bool,

--- a/src/feature_selection/variance_threshold.rs
+++ b/src/feature_selection/variance_threshold.rs
@@ -11,6 +11,9 @@ use polars::prelude::*;
 /// Features with variance below `threshold` are removed. By default (threshold `0.0`),
 /// only constant features are removed.
 ///
+/// Only `Float64` columns are considered; columns of other dtypes are silently
+/// dropped from the output.
+///
 /// # Example
 ///
 /// ```rust
@@ -44,10 +47,10 @@ impl Default for VarianceThreshold {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for VarianceThreshold {
+impl Fit<DataFrame> for VarianceThreshold {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if x.width() == 0 {
             return Err(Error::InvalidInput(
                 "VarianceThreshold.fit received a DataFrame with 0 columns. \
@@ -146,9 +149,8 @@ mod tests {
     fn test_variance_threshold_removes_low_var() {
         let mut vt = VarianceThreshold::new(0.1);
         let df = make_test_df();
-        let y = df.clone();
 
-        vt.fit(df.clone(), y).unwrap();
+        vt.fit(df.clone()).unwrap();
         let result = vt.transform(df).unwrap();
 
         assert_eq!(result.width(), 1);
@@ -159,9 +161,8 @@ mod tests {
     fn test_variance_threshold_zero_keeps_all() {
         let mut vt = VarianceThreshold::new(0.0);
         let df = make_test_df();
-        let y = df.clone();
 
-        vt.fit(df.clone(), y).unwrap();
+        vt.fit(df.clone()).unwrap();
         let result = vt.transform(df).unwrap();
 
         assert_eq!(result.width(), 2);

--- a/src/feature_selection/variance_threshold.rs
+++ b/src/feature_selection/variance_threshold.rs
@@ -66,11 +66,23 @@ impl Fit<DataFrame, DataFrame> for VarianceThreshold {
         let mut selected = Vec::new();
         for col in x.columns() {
             let name = col.name().to_string();
-            let s = x.column(&name).unwrap();
+            let s = x.column(&name).map_err(|e| {
+                Error::InvalidInput(format!(
+                    "VarianceThreshold.fit: column '{}' not found. {}",
+                    name, e
+                ))
+            })?;
             if s.dtype() != &DataType::Float64 {
                 continue;
             }
-            let ca = s.f64().unwrap();
+            let ca = s.f64().map_err(|e| {
+                Error::InvalidInput(format!(
+                    "VarianceThreshold.fit: column '{}' has dtype {}; expected Float64. {}",
+                    name,
+                    s.dtype(),
+                    e
+                ))
+            })?;
             let mean = ca.mean().unwrap_or(0.0);
             let var =
                 ca.iter().flatten().map(|v| (v - mean).powi(2)).sum::<f64>() / ca.len() as f64;
@@ -107,7 +119,13 @@ impl Transform<DataFrame> for VarianceThreshold {
                     .into(),
             ));
         }
-        let cols = self.selected_columns.as_ref().unwrap();
+        let cols = self.selected_columns.as_ref().ok_or_else(|| {
+            Error::NotFitted(
+                "VarianceThreshold has not been fitted. \
+                 Call .fit(dataframe, target) before .transform()."
+                    .into(),
+            )
+        })?;
         let refs: Vec<&str> = cols.iter().map(|s| s.as_str()).collect();
         x.select(refs)
             .map_err(|e| Error::Computation(e.to_string()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub mod prelude {
     pub use crate::preprocessing::feature_hasher::FeatureHasher;
     pub use crate::preprocessing::imputer::SimpleImputer;
     pub use crate::preprocessing::imputer::Strategy;
+    pub use crate::preprocessing::missing_indicator::MissingIndicator;
     pub use crate::preprocessing::normalizer::Norm;
     pub use crate::preprocessing::normalizer::Normalizer;
     pub use crate::preprocessing::polynomial_features::PolynomialFeatures;
@@ -70,8 +71,7 @@ pub mod prelude {
     pub use crate::time_series::diff::Difference;
     pub use crate::time_series::lag::Lagger;
     pub use crate::time_series::rolling::RollingAggregator;
-    pub use crate::traits::missing_indicator::MissingIndicator;
-    pub use crate::traits::{Error, Fit, FitTransform, Result, Transform};
+    pub use crate::traits::{Error, Fit, FitSupervised, FitTransform, Result, Transform};
 }
 
 // --- Shallow re-exports at crate root ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,18 @@
 //! | [`traits`] | Core `Fit`, `Transform`, `FitTransform` traits and error types |
 //! | [`time_series`] | Lag features, rolling windows, difference, cyclical encoding |
 
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+// Tracked for removal in Phase 5: production `unwrap()`/`expect()` calls are
+// replaced with `Result`-based errors, after which this is flipped to deny.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 pub mod feature_selection;
 pub mod pipeline;
 pub mod preprocessing;
 pub mod time_series;
 pub mod traits;
+pub mod util;
 
 /// Convenient glob import of the most common types.
 ///
@@ -67,32 +74,7 @@ pub mod prelude {
 }
 
 // --- Shallow re-exports at crate root ---
-
-pub use crate::feature_selection::SelectKBest;
-pub use crate::feature_selection::VarianceThreshold;
-pub use crate::feature_selection::select_kbest::FClassif;
-pub use crate::pipeline::ColumnTransformer;
-pub use crate::pipeline::DataFrameTransformer;
-pub use crate::pipeline::Pipeline;
-pub use crate::pipeline::column_transformer::Remainder;
-pub use crate::preprocessing::auto_type::{AutoTypeDetector, ColumnType};
-pub use crate::preprocessing::binarizer::Binarizer;
-pub use crate::preprocessing::encoder::LabelEncoder;
-pub use crate::preprocessing::encoder::OneHotEncoder;
-pub use crate::preprocessing::encoder::OrdinalEncoder;
-pub use crate::preprocessing::feature_hasher::FeatureHasher;
-pub use crate::preprocessing::imputer::SimpleImputer;
-pub use crate::preprocessing::imputer::Strategy;
-pub use crate::preprocessing::normalizer::Norm;
-pub use crate::preprocessing::normalizer::Normalizer;
-pub use crate::preprocessing::polynomial_features::PolynomialFeatures;
-pub use crate::preprocessing::polynomial_features::PolynomialFeaturesBuilder;
-pub use crate::preprocessing::scaler::MinMaxScaler;
-pub use crate::preprocessing::scaler::RobustScaler;
-pub use crate::preprocessing::scaler::StandardScaler;
-pub use crate::time_series::cyclical::CyclicalEncoder;
-pub use crate::time_series::diff::Difference;
-pub use crate::time_series::lag::Lagger;
-pub use crate::time_series::rolling::RollingAggregator;
-pub use crate::traits::missing_indicator::MissingIndicator;
-pub use crate::traits::{Error, Fit, FitTransform, Result, Transform};
+// The canonical list lives in `prelude`; the root re-exports it so that
+// `featrs::StandardScaler` and `featrs::prelude::StandardScaler` both work.
+// Add new public types to `prelude` only.
+pub use crate::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,10 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
-// Tracked for removal in Phase 5: production `unwrap()`/`expect()` calls are
-// replaced with `Result`-based errors, after which this is flipped to deny.
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+// Production code must not `unwrap()`/`expect()` Polars results — route every
+// failure through `Error` instead. Tests are exempt.
+#![deny(clippy::unwrap_used, clippy::expect_used)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod feature_selection;
 pub mod pipeline;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,18 @@
 //!
 //! # Quick start
 //!
-//! ```rust,ignore
+//! ```rust
 //! use featrs::prelude::*;
+//! use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+//!
+//! let col = Column::from(Series::new("x".into(), &[1.0_f64, 2.0, 3.0]));
+//! let df = DataFrame::new(3, vec![col])?;
 //!
 //! let mut scaler = StandardScaler::new();
-//! scaler.fit(df.clone(), target)?;
+//! scaler.fit(df.clone())?;
 //! let scaled = scaler.transform(df)?;
+//! assert_eq!(scaled.height(), 3);
+//! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
 //! # Modules
@@ -40,8 +46,10 @@ pub mod util;
 
 /// Convenient glob import of the most common types.
 ///
-/// ```rust,ignore
+/// ```rust
 /// use featrs::prelude::*;
+///
+/// let _scaler = StandardScaler::new();
 /// ```
 pub mod prelude {
     pub use crate::feature_selection::SelectKBest;

--- a/src/pipeline/column_transformer.rs
+++ b/src/pipeline/column_transformer.rs
@@ -207,4 +207,50 @@ mod tests {
         let result = ct.transform(df).unwrap();
         assert_eq!(result.width(), 3);
     }
+
+    #[test]
+    fn test_column_transformer_drop_remainder() {
+        let scaler = StandardScaler::new();
+        let mut ct = ColumnTransformer::new(
+            vec![("scale_a".into(), Box::new(scaler), vec!["a".into()])],
+            Remainder::Drop,
+        );
+        let df = make_test_df();
+
+        ct.fit(df.clone()).unwrap();
+        let result = ct.transform(df).unwrap();
+        // Only the transformed "a" column is kept; b and c are dropped.
+        assert_eq!(result.width(), 1);
+        assert_eq!(result.height(), 3);
+    }
+
+    #[test]
+    fn test_column_transformer_multiple() {
+        let scaler_a = StandardScaler::new();
+        let scaler_b = StandardScaler::new();
+        let mut ct = ColumnTransformer::new(
+            vec![
+                ("scale_a".into(), Box::new(scaler_a), vec!["a".into()]),
+                ("scale_b".into(), Box::new(scaler_b), vec!["b".into()]),
+            ],
+            Remainder::Passthrough,
+        );
+        let df = make_test_df();
+
+        ct.fit(df.clone()).unwrap();
+        let result = ct.transform(df).unwrap();
+        // a (scaled) + b (scaled) + c (passthrough) = 3 columns.
+        assert_eq!(result.width(), 3);
+    }
+
+    #[test]
+    fn test_column_transformer_not_fitted() {
+        let scaler = StandardScaler::new();
+        let ct = ColumnTransformer::new(
+            vec![("scale_a".into(), Box::new(scaler), vec!["a".into()])],
+            Remainder::Passthrough,
+        );
+        let df = make_test_df();
+        assert!(ct.transform(df).is_err());
+    }
 }

--- a/src/pipeline/column_transformer.rs
+++ b/src/pipeline/column_transformer.rs
@@ -69,10 +69,10 @@ impl ColumnTransformer {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for ColumnTransformer {
+impl Fit<DataFrame> for ColumnTransformer {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if x.width() == 0 {
             return Err(Error::InvalidInput(
                 "ColumnTransformer.fit received a DataFrame with 0 columns.".into(),
@@ -93,8 +93,7 @@ impl Fit<DataFrame, DataFrame> for ColumnTransformer {
                     e
                 ))
             })?;
-            let y_dummy = subset.clone();
-            transformer.fit(subset, y_dummy).map_err(|e| {
+            transformer.fit(subset).map_err(|e| {
                 Error::Computation(format!(
                     "ColumnTransformer: transformer '{}' failed during fit: {}",
                     t_name, e
@@ -202,9 +201,8 @@ mod tests {
             Remainder::Passthrough,
         );
         let df = make_test_df();
-        let y = df.clone();
 
-        ct.fit(df.clone(), y).unwrap();
+        ct.fit(df.clone()).unwrap();
         let result = ct.transform(df).unwrap();
         assert_eq!(result.width(), 3);
     }

--- a/src/pipeline/column_transformer.rs
+++ b/src/pipeline/column_transformer.rs
@@ -29,10 +29,11 @@ pub enum Remainder {
 /// use featrs::pipeline::column_transformer::Remainder;
 /// use featrs::preprocessing::scaler::StandardScaler;
 ///
-/// let ct = ColumnTransformer::new(
+/// let _ct = ColumnTransformer::new(
 ///     vec![("scale".into(), Box::new(StandardScaler::new()), vec!["feat_a".into()])],
 ///     Remainder::Passthrough,
 /// );
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct ColumnTransformer {
     transformers: Vec<(String, Box<dyn DataFrameTransformer>, Vec<String>)>,

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -15,25 +15,22 @@ use polars::prelude::*;
 /// Trait alias for [`Box<dyn ...>`](Box) type erasure in [`Pipeline`] and [`ColumnTransformer`].
 ///
 /// Automatically implemented for any type that satisfies both
-/// [`Fit<DataFrame, DataFrame, Output = ()>`](Fit) and
-/// [`Transform<DataFrame, Output = DataFrame>`](Transform).
+/// [`Fit<DataFrame, Output = ()>`](crate::traits::Fit) and
+/// [`Transform<DataFrame, Output = DataFrame>`](crate::traits::Transform).
 pub trait DataFrameTransformer:
-    Fit<DataFrame, DataFrame, Output = ()> + Transform<DataFrame, Output = DataFrame>
+    Fit<DataFrame, Output = ()> + Transform<DataFrame, Output = DataFrame>
 {
 }
 impl<T> DataFrameTransformer for T where
-    T: Fit<DataFrame, DataFrame, Output = ()> + Transform<DataFrame, Output = DataFrame>
+    T: Fit<DataFrame, Output = ()> + Transform<DataFrame, Output = DataFrame>
 {
 }
 
 /// Sequential pipeline of data transformations.
 ///
-/// Each step is `(name, transformer)`. Calling `fit(X, y)` fits all steps
-/// sequentially. Calling `transform(X)` passes data through every step.
-///
-/// # Panics
-///
-/// Panics if `steps` is empty.
+/// Each step is `(name, transformer)`. Calling `fit(X)` fits all steps
+/// sequentially (passing each step's output into the next). Calling
+/// `transform(X)` passes data through every step.
 ///
 /// # Example
 ///
@@ -43,7 +40,8 @@ impl<T> DataFrameTransformer for T where
 ///
 /// let mut pipeline = Pipeline::new(vec![
 ///     ("scale".into(), Box::new(StandardScaler::new())),
-/// ]);
+/// ]).unwrap();
+/// # let _ = pipeline;
 /// ```
 pub struct Pipeline {
     steps: Vec<(String, Box<dyn DataFrameTransformer>)>,
@@ -55,16 +53,16 @@ impl Pipeline {
     /// Each step is a `(name, transformer)` pair. The name is used for
     /// inspection and debugging.
     ///
-    /// # Panics
-    ///
-    /// Panics if `steps` is empty.
-    pub fn new(steps: Vec<(String, Box<dyn DataFrameTransformer>)>) -> Self {
-        assert!(
-            !steps.is_empty(),
-            "Pipeline::new: at least one step is required. \
-             Provide a non-empty Vec of (name, transformer) pairs."
-        );
-        Self { steps }
+    /// Returns [`Error::InvalidInput`] if `steps` is empty.
+    pub fn new(steps: Vec<(String, Box<dyn DataFrameTransformer>)>) -> Result<Self> {
+        if steps.is_empty() {
+            return Err(Error::InvalidInput(
+                "Pipeline::new: at least one step is required. \
+                 Provide a non-empty Vec of (name, transformer) pairs."
+                    .into(),
+            ));
+        }
+        Ok(Self { steps })
     }
 
     /// Returns a reference to the pipeline steps.
@@ -73,28 +71,25 @@ impl Pipeline {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for Pipeline {
+impl Fit<DataFrame> for Pipeline {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if x.height() == 0 {
             return Err(Error::InvalidInput(
                 "Pipeline.fit received a DataFrame with 0 rows.".into(),
             ));
         }
         let mut x_curr = x;
-        let y_curr = y;
         let n = self.steps.len();
         for (i, (name, transformer)) in self.steps.iter_mut().enumerate() {
             let is_last = i == n - 1;
-            transformer
-                .fit(x_curr.clone(), y_curr.clone())
-                .map_err(|e| {
-                    Error::Computation(format!(
-                        "Pipeline: step {} ('{}') failed during fit: {}",
-                        i, name, e
-                    ))
-                })?;
+            transformer.fit(x_curr.clone()).map_err(|e| {
+                Error::Computation(format!(
+                    "Pipeline: step {} ('{}') failed during fit: {}",
+                    i, name, e
+                ))
+            })?;
             if !is_last {
                 x_curr = transformer.transform(x_curr).map_err(|e| {
                     Error::Computation(format!(
@@ -139,11 +134,10 @@ mod tests {
     #[test]
     fn test_pipeline_single_step() {
         let scaler = StandardScaler::new();
-        let mut pipeline = Pipeline::new(vec![("scaler".into(), Box::new(scaler))]);
+        let mut pipeline = Pipeline::new(vec![("scaler".into(), Box::new(scaler))]).unwrap();
         let df = make_test_df();
-        let y = df.clone();
 
-        pipeline.fit(df.clone(), y).unwrap();
+        pipeline.fit(df.clone()).unwrap();
         let result = pipeline.transform(df).unwrap();
 
         assert_eq!(result.width(), 2);

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -37,11 +37,19 @@ impl<T> DataFrameTransformer for T where
 /// ```rust
 /// use featrs::pipeline::Pipeline;
 /// use featrs::preprocessing::scaler::StandardScaler;
+/// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let col = Column::from(Series::new("x".into(), &[1.0_f64, 2.0, 3.0]));
+/// let df = DataFrame::new(3, vec![col])?;
 ///
 /// let mut pipeline = Pipeline::new(vec![
 ///     ("scale".into(), Box::new(StandardScaler::new())),
-/// ]).unwrap();
-/// # let _ = pipeline;
+/// ])?;
+/// pipeline.fit(df.clone())?;
+/// let result = pipeline.transform(df)?;
+/// assert_eq!(result.height(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct Pipeline {
     steps: Vec<(String, Box<dyn DataFrameTransformer>)>,

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -131,6 +131,7 @@ impl Transform<DataFrame> for Pipeline {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::preprocessing::binarizer::Binarizer;
     use crate::preprocessing::scaler::StandardScaler;
 
     fn make_test_df() -> DataFrame {
@@ -150,5 +151,37 @@ mod tests {
 
         assert_eq!(result.width(), 2);
         assert_eq!(result.height(), 3);
+    }
+
+    #[test]
+    fn test_pipeline_multi_step() {
+        let scaler = StandardScaler::new();
+        let binarizer = Binarizer::new(0.0);
+        let mut pipeline = Pipeline::new(vec![
+            ("scaler".into(), Box::new(scaler)),
+            ("binarizer".into(), Box::new(binarizer)),
+        ])
+        .unwrap();
+        let df = make_test_df();
+
+        pipeline.fit(df.clone()).unwrap();
+        let result = pipeline.transform(df).unwrap();
+
+        assert_eq!(result.width(), 2);
+        assert_eq!(result.height(), 3);
+    }
+
+    #[test]
+    fn test_pipeline_empty_steps_error() {
+        let result = Pipeline::new(vec![]);
+        assert!(result.is_err(), "Pipeline::new must reject empty steps");
+    }
+
+    #[test]
+    fn test_pipeline_not_fitted() {
+        let scaler = StandardScaler::new();
+        let pipeline = Pipeline::new(vec![("scaler".into(), Box::new(scaler))]).unwrap();
+        let df = make_test_df();
+        assert!(pipeline.transform(df).is_err());
     }
 }

--- a/src/preprocessing/auto_type.rs
+++ b/src/preprocessing/auto_type.rs
@@ -174,8 +174,14 @@ impl Transform<DataFrame> for AutoTypeDetector {
         if !self.fitted {
             return Err(Error::NotFitted("AutoTypeDetector".into()));
         }
-        let types = self.column_types.as_ref().unwrap();
-        let encoders = self.encoders.as_ref().unwrap();
+        let types = self
+            .column_types
+            .as_ref()
+            .ok_or_else(|| Error::NotFitted("AutoTypeDetector has not been fitted.".into()))?;
+        let encoders = self
+            .encoders
+            .as_ref()
+            .ok_or_else(|| Error::NotFitted("AutoTypeDetector has not been fitted.".into()))?;
         let mut parts: Vec<DataFrame> = Vec::new();
         let mut numeric_cols: Vec<Column> = Vec::new();
 

--- a/src/preprocessing/auto_type.rs
+++ b/src/preprocessing/auto_type.rs
@@ -87,10 +87,10 @@ impl Default for AutoTypeDetector {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for AutoTypeDetector {
+impl Fit<DataFrame> for AutoTypeDetector {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         let mut types = Vec::new();
         let mut encoders: Vec<(String, Box<dyn DataFrameTransformer>)> = Vec::new();
 
@@ -132,7 +132,7 @@ impl Fit<DataFrame, DataFrame> for AutoTypeDetector {
                         .select([name.as_str()])
                         .map_err(|e| Error::Computation(e.to_string()))?;
                     let mut enc = OneHotEncoder::new();
-                    enc.fit(subset.clone(), subset.clone()).map_err(|e| {
+                    enc.fit(subset.clone()).map_err(|e| {
                         Error::Computation(format!(
                             "AutoType.fit: one-hot failed on '{}': {}",
                             name, e
@@ -146,7 +146,7 @@ impl Fit<DataFrame, DataFrame> for AutoTypeDetector {
                         .select([name.as_str()])
                         .map_err(|e| Error::Computation(e.to_string()))?;
                     let mut fh = FeatureHasher::new(&[name.as_str()], self.hash_buckets);
-                    fh.fit(subset.clone(), subset.clone()).map_err(|e| {
+                    fh.fit(subset.clone()).map_err(|e| {
                         Error::Computation(format!(
                             "AutoType.fit: hashing failed on '{}': {}",
                             name, e
@@ -262,7 +262,7 @@ mod tests {
     fn test_auto_type_detect_and_transform() {
         let mut atd = AutoTypeDetector::new().cat_threshold(5).hash_buckets(8);
         let df = make_test_df();
-        atd.fit(df.clone(), df.clone()).unwrap();
+        atd.fit(df.clone()).unwrap();
 
         // `cat` has 2 uniques (< threshold 5) -> Categorical; `high` has 3
         // uniques but threshold is 5 so also Categorical here. Bump threshold
@@ -288,7 +288,7 @@ mod tests {
     fn test_auto_type_transform_is_idempotent() {
         let mut atd = AutoTypeDetector::new().cat_threshold(5).hash_buckets(8);
         let df = make_test_df();
-        atd.fit(df.clone(), df.clone()).unwrap();
+        atd.fit(df.clone()).unwrap();
 
         let out1 = atd.transform(df.clone()).unwrap();
         let out2 = atd.transform(df).unwrap();

--- a/src/preprocessing/auto_type.rs
+++ b/src/preprocessing/auto_type.rs
@@ -33,11 +33,17 @@ pub enum ColumnType {
 /// ```rust
 /// use featrs::preprocessing::auto_type::AutoTypeDetector;
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let num = Column::from(Series::new("num".into(), &[1.0_f64, 2.0, 3.0]));
+/// let cat = Column::from(Series::new("cat".into(), &["a", "b", "a"]));
+/// let df = DataFrame::new(3, vec![num, cat])?;
 ///
 /// let mut atd = AutoTypeDetector::new();
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // atd.fit(df.clone(), target)?;
-/// // let typed = atd.transform(df)?;
+/// atd.fit(df.clone())?;
+/// let typed = atd.transform(df)?;
+/// assert_eq!(typed.height(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct AutoTypeDetector {
     fitted: bool,

--- a/src/preprocessing/auto_type.rs
+++ b/src/preprocessing/auto_type.rs
@@ -4,6 +4,9 @@
 //! applies appropriate transformations (e.g., one-hot for low-cardinality
 //! strings, pass-through for floats).
 
+use crate::pipeline::DataFrameTransformer;
+use crate::preprocessing::encoder::OneHotEncoder;
+use crate::preprocessing::feature_hasher::FeatureHasher;
 use crate::traits::{Error, Fit, Result, Transform};
 use polars::prelude::*;
 
@@ -41,15 +44,21 @@ pub struct AutoTypeDetector {
     cat_threshold: usize,
     hash_buckets: usize,
     column_types: Option<Vec<(String, ColumnType)>>,
+    /// Fitted sub-transformers for the non-numeric columns, in frame order.
+    /// Learned once during `fit` and reused on every `transform` call so the
+    /// learned categories / hash mapping do not drift with the transform data.
+    encoders: Option<Vec<(String, Box<dyn DataFrameTransformer>)>>,
 }
 
 impl AutoTypeDetector {
+    /// Create a new detector with defaults: `cat_threshold = 20`, `hash_buckets = 100`.
     pub fn new() -> Self {
         Self {
             fitted: false,
             cat_threshold: 20,
             hash_buckets: 100,
             column_types: None,
+            encoders: None,
         }
     }
 
@@ -83,6 +92,7 @@ impl Fit<DataFrame, DataFrame> for AutoTypeDetector {
 
     fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
         let mut types = Vec::new();
+        let mut encoders: Vec<(String, Box<dyn DataFrameTransformer>)> = Vec::new();
 
         for col in x.columns() {
             let name = col.name().to_string();
@@ -113,10 +123,45 @@ impl Fit<DataFrame, DataFrame> for AutoTypeDetector {
                 _ => ColumnType::Numeric,
             };
 
+            // For non-numeric columns, fit the corresponding sub-transformer on
+            // the fit data now, so transform() never has to re-fit.
+            match detected {
+                ColumnType::Categorical => {
+                    let subset = x
+                        .clone()
+                        .select([name.as_str()])
+                        .map_err(|e| Error::Computation(e.to_string()))?;
+                    let mut enc = OneHotEncoder::new();
+                    enc.fit(subset.clone(), subset.clone()).map_err(|e| {
+                        Error::Computation(format!(
+                            "AutoType.fit: one-hot failed on '{}': {}",
+                            name, e
+                        ))
+                    })?;
+                    encoders.push((name.clone(), Box::new(enc)));
+                }
+                ColumnType::HighCardinality => {
+                    let subset = x
+                        .clone()
+                        .select([name.as_str()])
+                        .map_err(|e| Error::Computation(e.to_string()))?;
+                    let mut fh = FeatureHasher::new(&[name.as_str()], self.hash_buckets);
+                    fh.fit(subset.clone(), subset.clone()).map_err(|e| {
+                        Error::Computation(format!(
+                            "AutoType.fit: hashing failed on '{}': {}",
+                            name, e
+                        ))
+                    })?;
+                    encoders.push((name.clone(), Box::new(fh)));
+                }
+                ColumnType::Numeric => {}
+            }
+
             types.push((name, detected));
         }
 
         self.column_types = Some(types);
+        self.encoders = Some(encoders);
         self.fitted = true;
         Ok(())
     }
@@ -130,6 +175,7 @@ impl Transform<DataFrame> for AutoTypeDetector {
             return Err(Error::NotFitted("AutoTypeDetector".into()));
         }
         let types = self.column_types.as_ref().unwrap();
+        let encoders = self.encoders.as_ref().unwrap();
         let mut parts: Vec<DataFrame> = Vec::new();
         let mut numeric_cols: Vec<Column> = Vec::new();
 
@@ -140,44 +186,31 @@ impl Transform<DataFrame> for AutoTypeDetector {
                         numeric_cols.push(col.clone());
                     }
                 }
-                ColumnType::Categorical => {
+                ColumnType::Categorical | ColumnType::HighCardinality => {
+                    // Sub-transformers were fitted during `fit`; reuse them so
+                    // learned categories / hash mapping are stable across calls.
+                    let enc = encoders
+                        .iter()
+                        .find(|(n, _)| n == name)
+                        .map(|(_, e)| e)
+                        .ok_or_else(|| {
+                            Error::Computation(format!(
+                                "AutoTypeDetector: no fitted encoder for column '{}'",
+                                name
+                            ))
+                        })?;
                     let subset = x
                         .clone()
                         .select([name.as_str()])
                         .map_err(|e| Error::Computation(e.to_string()))?;
-                    use crate::preprocessing::encoder::OneHotEncoder;
-                    let mut enc = OneHotEncoder::new();
-                    enc.fit(subset.clone(), subset.clone()).map_err(|e| {
-                        Error::Computation(format!("AutoType: one-hot failed on '{}': {}", name, e))
-                    })?;
-                    let encoded = enc.transform(subset).map_err(|e| {
+                    let out = enc.transform(subset).map_err(|e| {
                         Error::Computation(format!(
-                            "AutoType: one-hot transform failed on '{}': {}",
+                            "AutoTypeDetector.transform: '{}' failed: {}",
                             name, e
                         ))
                     })?;
-                    if !encoded.columns().is_empty() {
-                        parts.push(encoded);
-                    }
-                }
-                ColumnType::HighCardinality => {
-                    let subset = x
-                        .clone()
-                        .select([name.as_str()])
-                        .map_err(|e| Error::Computation(e.to_string()))?;
-                    use crate::preprocessing::feature_hasher::FeatureHasher;
-                    let mut fh = FeatureHasher::new(&[name.as_str()], self.hash_buckets);
-                    fh.fit(subset.clone(), subset.clone()).map_err(|e| {
-                        Error::Computation(format!("AutoType: hashing failed on '{}': {}", name, e))
-                    })?;
-                    let hashed = fh.transform(subset).map_err(|e| {
-                        Error::Computation(format!(
-                            "AutoType: hashing transform failed on '{}': {}",
-                            name, e
-                        ))
-                    })?;
-                    if !hashed.columns().is_empty() {
-                        parts.push(hashed);
+                    if !out.columns().is_empty() {
+                        parts.push(out);
                     }
                 }
             }
@@ -205,5 +238,76 @@ impl Transform<DataFrame> for AutoTypeDetector {
         }
 
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_df() -> DataFrame {
+        let num = Column::from(Series::new("num".into(), &[1.0f64, 2.0, 3.0]));
+        let cat = Column::from(Series::new("cat".into(), &["a", "b", "a"]));
+        let high = Column::from(Series::new("high".into(), &["x1", "x2", "x3"]));
+        DataFrame::new(3, vec![num, cat, high]).unwrap()
+    }
+
+    #[test]
+    fn test_auto_type_detect_and_transform() {
+        let mut atd = AutoTypeDetector::new().cat_threshold(5).hash_buckets(8);
+        let df = make_test_df();
+        atd.fit(df.clone(), df.clone()).unwrap();
+
+        // `cat` has 2 uniques (< threshold 5) -> Categorical; `high` has 3
+        // uniques but threshold is 5 so also Categorical here. Bump threshold
+        // down to push `high` into HighCardinality.
+        let types: std::collections::HashMap<&str, ColumnType> = atd
+            .column_types()
+            .unwrap()
+            .iter()
+            .map(|(n, t)| (n.as_str(), t.clone()))
+            .collect();
+        assert_eq!(types.get("num"), Some(&ColumnType::Numeric));
+        assert_eq!(types.get("cat"), Some(&ColumnType::Categorical));
+
+        let out = atd.transform(df).unwrap();
+        assert!(out.width() >= 1);
+        assert_eq!(out.height(), 3);
+    }
+
+    /// Regression: `transform` used to re-fit its sub-transformers on every
+    /// call, so learned categories could drift. Verify two consecutive
+    /// transforms on the same data produce identical output schemas.
+    #[test]
+    fn test_auto_type_transform_is_idempotent() {
+        let mut atd = AutoTypeDetector::new().cat_threshold(5).hash_buckets(8);
+        let df = make_test_df();
+        atd.fit(df.clone(), df.clone()).unwrap();
+
+        let out1 = atd.transform(df.clone()).unwrap();
+        let out2 = atd.transform(df).unwrap();
+
+        let names1: Vec<String> = out1
+            .get_column_names()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let names2: Vec<String> = out2
+            .get_column_names()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            names1, names2,
+            "transform schema must be stable across calls"
+        );
+        assert_eq!(out1.height(), out2.height());
+    }
+
+    #[test]
+    fn test_auto_type_not_fitted() {
+        let atd = AutoTypeDetector::new();
+        let df = make_test_df();
+        assert!(atd.transform(df).is_err());
     }
 }

--- a/src/preprocessing/binarizer.rs
+++ b/src/preprocessing/binarizer.rs
@@ -45,10 +45,10 @@ impl Default for Binarizer {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for Binarizer {
+impl Fit<DataFrame> for Binarizer {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if x.width() == 0 {
             return Err(Error::InvalidInput(
                 "Binarizer.fit received a DataFrame with 0 columns. \
@@ -109,9 +109,8 @@ mod tests {
         let mut b = Binarizer::default();
         let a = Column::from(Series::new("x".into(), &[-1.0f64, 0.0, 2.0]));
         let df = DataFrame::new(3, vec![a]).unwrap();
-        let y = df.clone();
 
-        b.fit(df.clone(), y).unwrap();
+        b.fit(df.clone()).unwrap();
         let result = b.transform(df).unwrap();
 
         let vals: Vec<f64> = result
@@ -132,9 +131,8 @@ mod tests {
         let mut b = Binarizer::new(5.0);
         let a = Column::from(Series::new("x".into(), &[1.0f64, 5.0, 10.0]));
         let df = DataFrame::new(3, vec![a]).unwrap();
-        let y = df.clone();
 
-        b.fit(df.clone(), y).unwrap();
+        b.fit(df.clone()).unwrap();
         let result = b.transform(df).unwrap();
 
         let vals: Vec<f64> = result

--- a/src/preprocessing/binarizer.rs
+++ b/src/preprocessing/binarizer.rs
@@ -4,6 +4,7 @@
 //! become `1.0`, others become `0.0`.
 
 use crate::traits::{Error, Fit, Result, Transform};
+use crate::util::replace_f64_column;
 use polars::prelude::*;
 
 /// Binarize data according to a threshold.
@@ -86,16 +87,12 @@ impl Transform<DataFrame> for Binarizer {
             .collect();
 
         let mut out = x.clone();
+        let threshold = self.threshold;
 
         for name in &col_names {
-            let s = out.column(name.as_str()).unwrap();
-            let ca = s.f64().unwrap();
-            let binarized: ChunkedArray<Float64Type> = ca
-                .iter()
-                .map(|opt| opt.map(|v| if v > self.threshold { 1.0 } else { 0.0 }))
-                .collect();
-            out.replace(name.as_str(), binarized.into_series().into())
-                .unwrap();
+            replace_f64_column(&mut out, name.as_str(), "Binarizer", |v| {
+                if v > threshold { 1.0 } else { 0.0 }
+            })?;
         }
 
         Ok(out)

--- a/src/preprocessing/binarizer.rs
+++ b/src/preprocessing/binarizer.rs
@@ -16,11 +16,16 @@ use polars::prelude::*;
 /// ```rust
 /// use featrs::preprocessing::binarizer::Binarizer;
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let col = Column::from(Series::new("x".into(), &[-1.0_f64, 0.5, 2.0]));
+/// let df = DataFrame::new(3, vec![col])?;
 ///
 /// let mut b = Binarizer::new(0.5);
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // b.fit(df.clone(), target)?;
-/// // let binarized = b.transform(df)?;
+/// b.fit(df.clone())?;
+/// let binarized = b.transform(df)?;
+/// assert_eq!(binarized.height(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct Binarizer {
     fitted: bool,

--- a/src/preprocessing/encoder.rs
+++ b/src/preprocessing/encoder.rs
@@ -41,11 +41,16 @@ fn column_unique_strings(col: &Column) -> Result<Vec<String>> {
 /// ```rust
 /// use featrs::preprocessing::encoder::OneHotEncoder;
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let col = Column::from(Series::new("color".into(), &["red", "blue", "red"]));
+/// let df = DataFrame::new(3, vec![col])?;
 ///
 /// let mut enc = OneHotEncoder::new().drop_first(false);
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // enc.fit(df.clone(), target)?;
-/// // let encoded = enc.transform(df)?;
+/// enc.fit(df.clone())?;
+/// let encoded = enc.transform(df)?;
+/// assert_eq!(encoded.width(), 2);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct OneHotEncoder {
     fitted: bool,
@@ -196,11 +201,16 @@ impl Transform<DataFrame> for OneHotEncoder {
 /// ```rust
 /// use featrs::preprocessing::encoder::LabelEncoder;
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let col = Column::from(Series::new("color".into(), &["red", "blue", "red"]));
+/// let df = DataFrame::new(3, vec![col])?;
 ///
 /// let mut enc = LabelEncoder::new();
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // enc.fit(df.clone(), target)?;
-/// // let encoded = enc.transform(df)?;
+/// enc.fit(df.clone())?;
+/// let encoded = enc.transform(df)?;
+/// assert_eq!(encoded.height(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct LabelEncoder {
     fitted: bool,
@@ -310,11 +320,16 @@ impl Transform<DataFrame> for LabelEncoder {
 /// ```rust
 /// use featrs::preprocessing::encoder::OrdinalEncoder;
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let col = Column::from(Series::new("color".into(), &["red", "blue", "red"]));
+/// let df = DataFrame::new(3, vec![col])?;
 ///
 /// let mut enc = OrdinalEncoder::new();
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // enc.fit(df.clone(), target)?;
-/// // let encoded = enc.transform(df)?;
+/// enc.fit(df.clone())?;
+/// let encoded = enc.transform(df)?;
+/// assert_eq!(encoded.height(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct OrdinalEncoder {
     fitted: bool,

--- a/src/preprocessing/encoder.rs
+++ b/src/preprocessing/encoder.rs
@@ -88,10 +88,10 @@ impl Default for OneHotEncoder {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for OneHotEncoder {
+impl Fit<DataFrame> for OneHotEncoder {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if x.height() == 0 {
             return Err(Error::InvalidInput(
                 "OneHotEncoder.fit received a DataFrame with 0 rows. \
@@ -225,10 +225,10 @@ impl Default for LabelEncoder {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for LabelEncoder {
+impl Fit<DataFrame> for LabelEncoder {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if x.width() != 1 {
             return Err(Error::InvalidInput(format!(
                 "LabelEncoder.fit expects a single column but got {} columns. \
@@ -337,10 +337,10 @@ impl Default for OrdinalEncoder {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for OrdinalEncoder {
+impl Fit<DataFrame> for OrdinalEncoder {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if x.width() == 0 {
             return Err(Error::InvalidInput(
                 "OrdinalEncoder.fit received a DataFrame with 0 columns. \
@@ -452,9 +452,8 @@ mod tests {
     fn test_one_hot_encoder() {
         let mut enc = OneHotEncoder::new();
         let df = make_categorical_df();
-        let y = df.clone();
 
-        enc.fit(df.clone(), y).unwrap();
+        enc.fit(df.clone()).unwrap();
         let result = enc.transform(df).unwrap();
 
         assert_eq!(result.width(), 6);
@@ -465,9 +464,8 @@ mod tests {
     fn test_one_hot_encoder_drop_first() {
         let mut enc = OneHotEncoder::new().drop_first(true);
         let df = make_categorical_df();
-        let y = df.clone();
 
-        enc.fit(df.clone(), y).unwrap();
+        enc.fit(df.clone()).unwrap();
         let result = enc.transform(df).unwrap();
 
         assert_eq!(result.width(), 4);
@@ -481,9 +479,8 @@ mod tests {
             &["red", "blue", "red", "green"],
         ));
         let df = DataFrame::new(4, vec![colors]).unwrap();
-        let y = df.clone();
 
-        enc.fit(df.clone(), y).unwrap();
+        enc.fit(df.clone()).unwrap();
         let result = enc.transform(df).unwrap();
 
         let vals: Vec<u32> = result
@@ -501,9 +498,8 @@ mod tests {
     fn test_ordinal_encoder() {
         let mut enc = OrdinalEncoder::new();
         let df = make_categorical_df();
-        let y = df.clone();
 
-        enc.fit(df.clone(), y).unwrap();
+        enc.fit(df.clone()).unwrap();
         let result = enc.transform(df).unwrap();
 
         let color_vals: Vec<u32> = result

--- a/src/preprocessing/encoder.rs
+++ b/src/preprocessing/encoder.rs
@@ -139,7 +139,13 @@ impl Transform<DataFrame> for OneHotEncoder {
                     .into(),
             ));
         }
-        let cats = self.categories.as_ref().unwrap();
+        let cats = self.categories.as_ref().ok_or_else(|| {
+            Error::NotFitted(
+                "OneHotEncoder has not been fitted. \
+                 Call .fit(dataframe, target) before .transform()."
+                    .into(),
+            )
+        })?;
         let mut new_cols: Vec<Column> = Vec::new();
         let n_rows = x.height();
 
@@ -265,7 +271,13 @@ impl Transform<DataFrame> for LabelEncoder {
                     .into(),
             ));
         }
-        let mapping = self.mapping.as_ref().unwrap();
+        let mapping = self.mapping.as_ref().ok_or_else(|| {
+            Error::NotFitted(
+                "LabelEncoder has not been fitted. \
+                 Call .fit(dataframe, target) before .transform()."
+                    .into(),
+            )
+        })?;
         let s = x.columns()[0].as_materialized_series();
         let ca = s.str().map_err(|e| {
             Error::InvalidInput(format!(
@@ -382,18 +394,21 @@ impl Transform<DataFrame> for OrdinalEncoder {
         }
         let mut out_cols = Vec::new();
 
-        for (name, mapping) in self.categories.as_ref().unwrap() {
+        let cats = self.categories.as_ref().ok_or_else(|| {
+            Error::NotFitted(
+                "OrdinalEncoder has not been fitted. \
+                 Call .fit(dataframe, target) before .transform()."
+                    .into(),
+            )
+        })?;
+
+        for (name, mapping) in cats {
             let s = x.column(name.as_str()).map_err(|e| {
                 Error::InvalidInput(format!(
                     "OrdinalEncoder.transform: column '{}' not found. \
                      The encoder was fitted on columns: {:?}. {}",
                     name,
-                    self.categories
-                        .as_ref()
-                        .unwrap()
-                        .iter()
-                        .map(|(n, _)| n)
-                        .collect::<Vec<_>>(),
+                    cats.iter().map(|(n, _)| n).collect::<Vec<_>>(),
                     e
                 ))
             })?;

--- a/src/preprocessing/feature_hasher.rs
+++ b/src/preprocessing/feature_hasher.rs
@@ -85,11 +85,21 @@ impl Transform<DataFrame> for FeatureHasher {
         let mut buckets = vec![vec![0.0f64; n_rows]; self.n_features];
 
         for col in &self.columns {
-            let s = x.column(col.as_str()).unwrap().as_materialized_series();
-            let ca = s.str().map_err(|_| {
+            let s = x
+                .column(col.as_str())
+                .map_err(|e| {
+                    Error::InvalidInput(format!(
+                        "FeatureHasher.transform: column '{}' not found. {}",
+                        col, e
+                    ))
+                })?
+                .as_materialized_series();
+            let ca = s.str().map_err(|e| {
                 Error::InvalidInput(format!(
-                    "FeatureHasher: column '{}' is not a string column.",
-                    col
+                    "FeatureHasher.transform: column '{}' has dtype {}; expected String. {}",
+                    col,
+                    s.dtype(),
+                    e
                 ))
             })?;
             for (i, opt) in ca.iter().enumerate() {

--- a/src/preprocessing/feature_hasher.rs
+++ b/src/preprocessing/feature_hasher.rs
@@ -2,7 +2,10 @@
 //!
 //! [`FeatureHasher`] maps categorical features into a fixed-size vector
 //! using a hash function, enabling memory-efficient encoding of
-//! high-cardinality categories.
+//! high-cardinality categories. Uses the signed hashing trick
+//! (Weinberger et al. 2009): a second independent hash determines the sign
+//! (`+1.0` / `-1.0`) of each addition, so the expected value of every bucket
+//! is zero and collisions do not bias the mean.
 
 use crate::traits::{Error, Fit, Result, Transform};
 use polars::prelude::*;
@@ -11,9 +14,10 @@ use std::hash::{Hash, Hasher};
 
 /// Map categorical columns to a fixed number of hash buckets.
 ///
-/// Each string cell is hashed to `0..n_features` and the corresponding
-/// bucket is incremented by 1.0. This avoids storing a category mapping
-/// and works with unseen categories at transform time.
+/// Each string cell is mapped to a `(bucket, sign)` pair via two independent
+/// hashes; the bucket is incremented by `sign` (`+1.0` or `-1.0`). This avoids
+/// storing a category mapping, works with unseen categories at transform time,
+/// and (unlike an unsigned trick) preserves a zero mean in expectation.
 ///
 /// # Example
 ///
@@ -23,7 +27,7 @@ use std::hash::{Hash, Hasher};
 ///
 /// let mut fh = FeatureHasher::new(&["text", "category"], 100);
 /// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // fh.fit(df.clone(), target)?;
+/// // fh.fit(df.clone())?;
 /// // let hashed = fh.transform(df)?;
 /// ```
 pub struct FeatureHasher {
@@ -45,17 +49,28 @@ impl FeatureHasher {
         }
     }
 
-    fn hash_to_index(s: &str, n: usize) -> usize {
-        let mut hasher = DefaultHasher::new();
-        s.hash(&mut hasher);
-        (hasher.finish() as usize) % n
+    /// Map `s` to a `(bucket, sign)` pair. Two independent `DefaultHasher`
+    /// instances (seeded differently) produce the index and the sign bit, so
+    /// collisions across the two are uncorrelated.
+    fn hash_to_bucket(s: &str, n: usize) -> (usize, f64) {
+        let mut h_idx = DefaultHasher::new();
+        0u8.hash(&mut h_idx);
+        s.hash(&mut h_idx);
+        let idx = (h_idx.finish() as usize) % n;
+
+        let mut h_sign = DefaultHasher::new();
+        1u8.hash(&mut h_sign);
+        s.hash(&mut h_sign);
+        let sign = if h_sign.finish() & 1 == 1 { 1.0 } else { -1.0 };
+
+        (idx, sign)
     }
 }
 
-impl Fit<DataFrame, DataFrame> for FeatureHasher {
+impl Fit<DataFrame> for FeatureHasher {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if self.n_features == 0 {
             return Err(Error::InvalidInput(
                 "FeatureHasher: n_features must be >= 1.".into(),
@@ -104,8 +119,8 @@ impl Transform<DataFrame> for FeatureHasher {
             })?;
             for (i, opt) in ca.iter().enumerate() {
                 if let Some(val) = opt {
-                    let idx = Self::hash_to_index(val, self.n_features);
-                    buckets[idx][i] += 1.0;
+                    let (idx, sign) = Self::hash_to_bucket(val, self.n_features);
+                    buckets[idx][i] += sign;
                 }
             }
         }
@@ -129,12 +144,47 @@ mod tests {
         let c = Column::from(Series::new("color".into(), &["red", "blue", "red"]));
         let df = DataFrame::new(3, vec![c]).unwrap();
         let mut fh = FeatureHasher::new(&["color"], 10);
-        let y = df.clone();
 
-        fh.fit(df.clone(), y).unwrap();
+        fh.fit(df.clone()).unwrap();
         let result = fh.transform(df).unwrap();
 
         assert_eq!(result.width(), 10);
         assert_eq!(result.height(), 3);
+    }
+
+    /// The signed hashing trick: `hash_to_bucket` returns a valid index and a
+    /// sign of exactly `+1.0` or `-1.0`, and is deterministic across calls.
+    #[test]
+    fn test_hash_to_bucket_signed_and_deterministic() {
+        for s in &["red", "blue", "green", "x", "y", "a very long category"] {
+            let (idx, sign) = FeatureHasher::hash_to_bucket(s, 64);
+            assert!(idx < 64, "index out of range for '{s}'");
+            assert!(sign == 1.0 || sign == -1.0, "sign must be ±1 for '{s}'");
+            // Determinism: same input, same output.
+            let (idx2, sign2) = FeatureHasher::hash_to_bucket(s, 64);
+            assert_eq!((idx, sign), (idx2, sign2));
+        }
+    }
+
+    /// Every non-zero bucket value produced by `transform` must be an integer
+    /// in `-1..=1` per single occurrence; summing repeated occurrences stays
+    /// an integer (the signed trick never produces fractional magnitudes).
+    #[test]
+    fn test_feature_hasher_signed_values() {
+        let c = Column::from(Series::new(
+            "color".into(),
+            &["red", "blue", "red", "green", "blue"],
+        ));
+        let df = DataFrame::new(5, vec![c]).unwrap();
+        let mut fh = FeatureHasher::new(&["color"], 32);
+        fh.fit(df.clone()).unwrap();
+        let result = fh.transform(df).unwrap();
+
+        for col in result.columns() {
+            for v in col.as_materialized_series().f64().unwrap().iter().flatten() {
+                let frac = v.fract();
+                assert!(frac == 0.0, "bucket value {v} must be integral");
+            }
+        }
     }
 }

--- a/src/preprocessing/feature_hasher.rs
+++ b/src/preprocessing/feature_hasher.rs
@@ -24,11 +24,16 @@ use std::hash::{Hash, Hasher};
 /// ```rust
 /// use featrs::preprocessing::feature_hasher::FeatureHasher;
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
 ///
-/// let mut fh = FeatureHasher::new(&["text", "category"], 100);
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // fh.fit(df.clone())?;
-/// // let hashed = fh.transform(df)?;
+/// let col = Column::from(Series::new("color".into(), &["red", "blue", "red"]));
+/// let df = DataFrame::new(3, vec![col])?;
+///
+/// let mut fh = FeatureHasher::new(&["color"], 10);
+/// fh.fit(df.clone())?;
+/// let hashed = fh.transform(df)?;
+/// assert_eq!(hashed.width(), 10);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct FeatureHasher {
     fitted: bool,

--- a/src/preprocessing/imputer.rs
+++ b/src/preprocessing/imputer.rs
@@ -73,10 +73,10 @@ impl SimpleImputer {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for SimpleImputer {
+impl Fit<DataFrame> for SimpleImputer {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if x.height() == 0 {
             return Err(Error::InvalidInput(
                 "SimpleImputer.fit received a DataFrame with 0 rows. \
@@ -238,9 +238,8 @@ mod tests {
     fn test_imputer_mean() {
         let mut imp = SimpleImputer::mean();
         let df = make_test_df();
-        let y = df.clone();
 
-        imp.fit(df.clone(), y).unwrap();
+        imp.fit(df.clone()).unwrap();
         let result = imp.transform(df).unwrap();
 
         let x_vals: Vec<f64> = result
@@ -268,9 +267,8 @@ mod tests {
     fn test_imputer_constant() {
         let mut imp = SimpleImputer::constant(0.0);
         let df = make_test_df();
-        let y = df.clone();
 
-        imp.fit(df.clone(), y).unwrap();
+        imp.fit(df.clone()).unwrap();
         let result = imp.transform(df).unwrap();
 
         let x_vals: Vec<f64> = result
@@ -296,7 +294,7 @@ mod tests {
         ));
         let df = DataFrame::new(4, vec![x]).unwrap();
         let mut imp = SimpleImputer::median();
-        imp.fit(df.clone(), df.clone()).unwrap();
+        imp.fit(df.clone()).unwrap();
         let _ = imp.transform(df).unwrap();
     }
 }

--- a/src/preprocessing/imputer.rs
+++ b/src/preprocessing/imputer.rs
@@ -301,4 +301,69 @@ mod tests {
         imp.fit(df.clone()).unwrap();
         let _ = imp.transform(df).unwrap();
     }
+
+    #[test]
+    fn test_imputer_median_value() {
+        // Non-null values [1.0, 3.0] → median = 2.0; the null at index 2 is
+        // imputed with 2.0.
+        let x = Column::from(Series::new("x".into(), &[Some(1.0f64), Some(3.0), None]));
+        let df = DataFrame::new(3, vec![x]).unwrap();
+        let mut imp = SimpleImputer::median();
+        imp.fit(df.clone()).unwrap();
+        let result = imp.transform(df).unwrap();
+
+        let vals: Vec<f64> = result
+            .column("x")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .iter()
+            .flatten()
+            .collect();
+        assert_relative_eq!(vals[2], 2.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_imputer_most_frequent_value() {
+        // Non-null values [1.0, 2.0, 2.0] → mode = 2.0; the null is imputed
+        // with 2.0.
+        let x = Column::from(Series::new(
+            "x".into(),
+            &[Some(1.0f64), Some(2.0), Some(2.0), None],
+        ));
+        let df = DataFrame::new(4, vec![x]).unwrap();
+        let mut imp = SimpleImputer::most_frequent();
+        imp.fit(df.clone()).unwrap();
+        let result = imp.transform(df).unwrap();
+
+        let vals: Vec<f64> = result
+            .column("x")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .iter()
+            .flatten()
+            .collect();
+        assert_relative_eq!(vals[3], 2.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_imputer_all_null_column_error() {
+        let x = Column::from(Series::new("x".into(), &[None::<f64>, None, None]));
+        let df = DataFrame::new(3, vec![x]).unwrap();
+        let mut imp = SimpleImputer::mean();
+        let fit_result = imp.fit(df.clone());
+        assert!(
+            fit_result.is_err(),
+            "fitting an all-null column with Mean must error"
+        );
+    }
+
+    #[test]
+    fn test_imputer_not_fitted() {
+        let imp = SimpleImputer::mean();
+        let x = Column::from(Series::new("x".into(), &[Some(1.0f64), None]));
+        let df = DataFrame::new(2, vec![x]).unwrap();
+        assert!(imp.transform(df).is_err());
+    }
 }

--- a/src/preprocessing/imputer.rs
+++ b/src/preprocessing/imputer.rs
@@ -91,7 +91,14 @@ impl Fit<DataFrame, DataFrame> for SimpleImputer {
             if col.dtype() != &DataType::Float64 {
                 continue;
             }
-            let ca = col.f64().unwrap();
+            let ca = col.f64().map_err(|e| {
+                Error::InvalidInput(format!(
+                    "SimpleImputer.fit: column '{}' has dtype {}; expected Float64. {}",
+                    name,
+                    col.dtype(),
+                    e
+                ))
+            })?;
             let all_vals: Vec<f64> = ca.iter().flatten().collect();
             let has_missing = ca.iter().any(|v| v.is_none());
 
@@ -142,7 +149,13 @@ impl Fit<DataFrame, DataFrame> for SimpleImputer {
                     for &v in &all_vals {
                         *freq.entry(v.to_bits()).or_default() += 1;
                     }
-                    let (max_key, _) = freq.into_iter().max_by_key(|&(_, c)| c).unwrap();
+                    let (max_key, _) =
+                        freq.into_iter().max_by_key(|&(_, c)| c).ok_or_else(|| {
+                            Error::Computation(format!(
+                                "SimpleImputer(MostFrequent): column '{}' has no non-null values",
+                                name
+                            ))
+                        })?;
                     f64::from_bits(max_key)
                 }
                 Strategy::Constant(v) => v,
@@ -168,7 +181,13 @@ impl Transform<DataFrame> for SimpleImputer {
                     .into(),
             ));
         }
-        let fill_values = self.fill_values.as_ref().unwrap();
+        let fill_values = self.fill_values.as_ref().ok_or_else(|| {
+            Error::NotFitted(
+                "SimpleImputer has not been fitted. \
+                 Call .fit(dataframe, target) before .transform()."
+                    .into(),
+            )
+        })?;
         let mut out = x.clone();
 
         for (name, fill) in fill_values {
@@ -192,7 +211,12 @@ impl Transform<DataFrame> for SimpleImputer {
             let filled: ChunkedArray<Float64Type> =
                 ca.iter().map(|opt| opt.or(Some(*fill))).collect();
             out.replace(name.as_str(), filled.into_series().into())
-                .unwrap();
+                .map_err(|e| {
+                    Error::Computation(format!(
+                        "SimpleImputer.transform: failed to replace column '{}'. {}",
+                        name, e
+                    ))
+                })?;
         }
 
         Ok(out)

--- a/src/preprocessing/imputer.rs
+++ b/src/preprocessing/imputer.rs
@@ -28,13 +28,17 @@ pub enum Strategy {
 ///
 /// ```rust
 /// use featrs::preprocessing::imputer::SimpleImputer;
-/// use featrs::preprocessing::imputer::Strategy;
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let col = Column::from(Series::new("x".into(), &[Some(1.0_f64), None, Some(3.0)]));
+/// let df = DataFrame::new(3, vec![col])?;
 ///
 /// let mut imp = SimpleImputer::mean();
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // imp.fit(df.clone(), target)?;
-/// // let filled = imp.transform(df)?;
+/// imp.fit(df.clone())?;
+/// let filled = imp.transform(df)?;
+/// assert_eq!(filled.height(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct SimpleImputer {
     fitted: bool,

--- a/src/preprocessing/imputer.rs
+++ b/src/preprocessing/imputer.rs
@@ -113,7 +113,7 @@ impl Fit<DataFrame, DataFrame> for SimpleImputer {
                 }
                 Strategy::Median => {
                     let mut sorted = all_vals.clone();
-                    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+                    sorted.sort_by(|a, b| a.total_cmp(b));
                     if sorted.is_empty() {
                         return Err(Error::Computation(format!(
                             "SimpleImputer(Median): column '{}' has no non-null values. \
@@ -258,5 +258,21 @@ mod tests {
             .flatten()
             .collect();
         assert_relative_eq!(x_vals[1], 0.0, epsilon = 1e-6);
+    }
+
+    /// Regression: the Median path sorted with `partial_cmp().unwrap()`, which
+    /// panicked when a NaN was present. `total_cmp` sorts NaN deterministically.
+    #[test]
+    fn test_imputer_median_with_nan_does_not_panic() {
+        // Column `x` has a NaN among the non-null values; the median sort must
+        // not panic.
+        let x = Column::from(Series::new(
+            "x".into(),
+            &[Some(1.0f64), Some(f64::NAN), None, Some(3.0)],
+        ));
+        let df = DataFrame::new(4, vec![x]).unwrap();
+        let mut imp = SimpleImputer::median();
+        imp.fit(df.clone(), df.clone()).unwrap();
+        let _ = imp.transform(df).unwrap();
     }
 }

--- a/src/preprocessing/missing_indicator.rs
+++ b/src/preprocessing/missing_indicator.rs
@@ -15,12 +15,12 @@ use polars::prelude::*;
 /// # Example
 ///
 /// ```rust
-/// use featrs::traits::missing_indicator::MissingIndicator;
+/// use featrs::preprocessing::missing_indicator::MissingIndicator;
 /// use featrs::traits::{Fit, Transform};
 ///
 /// let mut ind = MissingIndicator::new(&["age", "income"]);
 /// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // ind.fit(df.clone(), target)?;
+/// // ind.fit(df.clone())?;
 /// // let marked = ind.transform(df)?;
 /// ```
 pub struct MissingIndicator {
@@ -50,10 +50,10 @@ impl MissingIndicator {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for MissingIndicator {
+impl Fit<DataFrame> for MissingIndicator {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if self.all_columns {
             self.columns = x.get_column_names().iter().map(|s| s.to_string()).collect();
         }
@@ -128,9 +128,8 @@ mod tests {
         let a = Column::from(Series::new("x".into(), &[Some(1.0f64), None, Some(3.0)]));
         let df = DataFrame::new(3, vec![a]).unwrap();
         let mut ind = MissingIndicator::new(&["x"]);
-        let y = df.clone();
 
-        ind.fit(df.clone(), y).unwrap();
+        ind.fit(df.clone()).unwrap();
         let result = ind.transform(df).unwrap();
 
         assert_eq!(result.width(), 2); // x, x_missing

--- a/src/preprocessing/missing_indicator.rs
+++ b/src/preprocessing/missing_indicator.rs
@@ -17,11 +17,16 @@ use polars::prelude::*;
 /// ```rust
 /// use featrs::preprocessing::missing_indicator::MissingIndicator;
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
 ///
-/// let mut ind = MissingIndicator::new(&["age", "income"]);
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // ind.fit(df.clone())?;
-/// // let marked = ind.transform(df)?;
+/// let col = Column::from(Series::new("x".into(), &[Some(1.0_f64), None, Some(3.0)]));
+/// let df = DataFrame::new(3, vec![col])?;
+///
+/// let mut ind = MissingIndicator::new(&["x"]);
+/// ind.fit(df.clone())?;
+/// let marked = ind.transform(df)?;
+/// assert_eq!(marked.height(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct MissingIndicator {
     fitted: bool,

--- a/src/preprocessing/mod.rs
+++ b/src/preprocessing/mod.rs
@@ -9,6 +9,7 @@ pub mod binarizer;
 pub mod encoder;
 pub mod feature_hasher;
 pub mod imputer;
+pub mod missing_indicator;
 pub mod normalizer;
 pub mod polynomial_features;
 pub mod scaler;

--- a/src/preprocessing/normalizer.rs
+++ b/src/preprocessing/normalizer.rs
@@ -122,7 +122,20 @@ impl Transform<DataFrame> for Normalizer {
 
         let mut col_data: Vec<Vec<f64>> = Vec::with_capacity(n_cols);
         for name in &col_names {
-            let ca = x.column(name).unwrap().f64().unwrap();
+            let s = x.column(name).map_err(|e| {
+                Error::InvalidInput(format!(
+                    "Normalizer.transform: column '{}' not found. {}",
+                    name, e
+                ))
+            })?;
+            let ca = s.f64().map_err(|e| {
+                Error::InvalidInput(format!(
+                    "Normalizer.transform: column '{}' has dtype {}; expected Float64. {}",
+                    name,
+                    s.dtype(),
+                    e
+                ))
+            })?;
             col_data.push(ca.iter().flatten().collect());
         }
 

--- a/src/preprocessing/normalizer.rs
+++ b/src/preprocessing/normalizer.rs
@@ -78,10 +78,10 @@ impl Default for Normalizer {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for Normalizer {
+impl Fit<DataFrame> for Normalizer {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if x.width() == 0 {
             return Err(Error::InvalidInput(
                 "Normalizer.fit received a DataFrame with 0 columns. \
@@ -175,9 +175,8 @@ mod tests {
     fn test_l2_normalization() {
         let mut n = Normalizer::l2();
         let df = make_test_df();
-        let y = df.clone();
 
-        n.fit(df.clone(), y).unwrap();
+        n.fit(df.clone()).unwrap();
         let result = n.transform(df).unwrap();
 
         let col_a = result.column("a").unwrap().f64().unwrap();
@@ -191,9 +190,8 @@ mod tests {
     fn test_l1_normalization() {
         let mut n = Normalizer::l1();
         let df = make_test_df();
-        let y = df.clone();
 
-        n.fit(df.clone(), y).unwrap();
+        n.fit(df.clone()).unwrap();
         let result = n.transform(df).unwrap();
 
         let col_a = result.column("a").unwrap().f64().unwrap();
@@ -206,9 +204,8 @@ mod tests {
     fn test_max_normalization() {
         let mut n = Normalizer::max();
         let df = make_test_df();
-        let y = df.clone();
 
-        n.fit(df.clone(), y).unwrap();
+        n.fit(df.clone()).unwrap();
         let result = n.transform(df).unwrap();
 
         let col_a = result.column("a").unwrap().f64().unwrap();

--- a/src/preprocessing/normalizer.rs
+++ b/src/preprocessing/normalizer.rs
@@ -15,13 +15,18 @@ use polars::prelude::*;
 ///
 /// ```rust
 /// use featrs::preprocessing::normalizer::Normalizer;
-/// use featrs::preprocessing::normalizer::Norm;
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let a = Column::from(Series::new("a".into(), &[3.0_f64, 0.0, 1.0]));
+/// let b = Column::from(Series::new("b".into(), &[4.0_f64, 0.0, 2.0]));
+/// let df = DataFrame::new(3, vec![a, b])?;
 ///
 /// let mut n = Normalizer::l2();
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // n.fit(df.clone(), target)?;
-/// // let normalized = n.transform(df)?;
+/// n.fit(df.clone())?;
+/// let normalized = n.transform(df)?;
+/// assert_eq!(normalized.height(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct Normalizer {
     fitted: bool,

--- a/src/preprocessing/polynomial_features.rs
+++ b/src/preprocessing/polynomial_features.rs
@@ -5,6 +5,7 @@
 //! `sklearn.preprocessing.PolynomialFeatures`.
 
 use crate::traits::{Error, Fit, Result, Transform};
+use crate::util::require_f64_columns;
 use polars::prelude::*;
 
 fn series_pow(s: &Series, exp: usize) -> Series {
@@ -104,23 +105,6 @@ impl PolynomialFeatures {
     pub fn include_bias(mut self, value: bool) -> Self {
         self.include_bias = value;
         self
-    }
-
-    fn numeric_f64_column_names(&self, df: &DataFrame) -> Vec<String> {
-        df.get_column_names()
-            .iter()
-            .filter_map(|name| {
-                if let Ok(s) = df.column(name) {
-                    if s.dtype() == &DataType::Float64 {
-                        Some(name.to_string())
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            })
-            .collect()
     }
 
     fn generate_powers(
@@ -248,19 +232,7 @@ impl Fit<DataFrame, DataFrame> for PolynomialFeatures {
                 "PolynomialFeatures.fit received an empty DataFrame (0 rows or 0 columns).".into(),
             ));
         }
-        let col_names = self.numeric_f64_column_names(&x);
-        if col_names.is_empty() {
-            let all_types: Vec<String> = x
-                .get_column_names()
-                .iter()
-                .filter_map(|n| x.column(n).ok().map(|c| format!("'{}' ({})", n, c.dtype())))
-                .collect();
-            return Err(Error::InvalidInput(format!(
-                "PolynomialFeatures.fit: no Float64 columns found. \
-                 Available columns: [{}]. PolynomialFeatures operates on f64 columns.",
-                all_types.join(", ")
-            )));
-        }
+        let col_names = require_f64_columns(&x, "PolynomialFeatures")?;
         self.input_columns = Some(col_names);
         self.fitted = true;
         Ok(())

--- a/src/preprocessing/polynomial_features.rs
+++ b/src/preprocessing/polynomial_features.rs
@@ -59,13 +59,19 @@ fn series_mul(a: &Series, b: &Series) -> Result<Series> {
 /// ```rust
 /// use featrs::preprocessing::polynomial_features::PolynomialFeatures;
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
 ///
-/// let mut pf = PolynomialFeatures::new(2).unwrap()
+/// let a = Column::from(Series::new("a".into(), &[1.0_f64, 2.0, 3.0]));
+/// let b = Column::from(Series::new("b".into(), &[4.0_f64, 5.0, 6.0]));
+/// let df = DataFrame::new(3, vec![a, b])?;
+///
+/// let mut pf = PolynomialFeatures::new(2)?
 ///     .include_bias(true)
 ///     .interaction_only(false);
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // pf.fit(df.clone())?;
-/// // let result = pf.transform(df)?;
+/// pf.fit(df.clone())?;
+/// let result = pf.transform(df)?;
+/// assert_eq!(result.height(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct PolynomialFeatures {
     fitted: bool,
@@ -101,12 +107,12 @@ impl PolynomialFeatures {
     /// ```rust
     /// use featrs::preprocessing::polynomial_features::PolynomialFeatures;
     ///
-    /// let pf = PolynomialFeatures::builder()
+    /// let _pf = PolynomialFeatures::builder()
     ///     .degree(3)
     ///     .include_bias(false)
     ///     .interaction_only(true)
-    ///     .build()
-    ///     .unwrap();
+    ///     .build()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn builder() -> PolynomialFeaturesBuilder {
         PolynomialFeaturesBuilder::default()

--- a/src/preprocessing/polynomial_features.rs
+++ b/src/preprocessing/polynomial_features.rs
@@ -60,11 +60,11 @@ fn series_mul(a: &Series, b: &Series) -> Result<Series> {
 /// use featrs::preprocessing::polynomial_features::PolynomialFeatures;
 /// use featrs::traits::{Fit, Transform};
 ///
-/// let mut pf = PolynomialFeatures::new(2)
+/// let mut pf = PolynomialFeatures::new(2).unwrap()
 ///     .include_bias(true)
 ///     .interaction_only(false);
 /// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // pf.fit(df.clone(), target)?;
+/// // pf.fit(df.clone())?;
 /// // let result = pf.transform(df)?;
 /// ```
 pub struct PolynomialFeatures {
@@ -78,21 +78,20 @@ pub struct PolynomialFeatures {
 impl PolynomialFeatures {
     /// Create a new `PolynomialFeatures` with the given maximum degree.
     ///
-    /// # Panics
-    ///
-    /// Panics if `degree` is `0`.
-    pub fn new(degree: usize) -> Self {
-        assert!(
-            degree >= 1,
-            "PolynomialFeatures::new: degree must be >= 1, got {degree}"
-        );
-        Self {
+    /// Returns [`Error::InvalidInput`] if `degree` is `0`.
+    pub fn new(degree: usize) -> Result<Self> {
+        if degree == 0 {
+            return Err(Error::InvalidInput(format!(
+                "PolynomialFeatures::new: degree must be >= 1, got {degree}"
+            )));
+        }
+        Ok(Self {
             fitted: false,
             degree,
             interaction_only: false,
             include_bias: true,
             input_columns: None,
-        }
+        })
     }
 
     /// Create a builder for more ergonomic configuration.
@@ -106,7 +105,8 @@ impl PolynomialFeatures {
     ///     .degree(3)
     ///     .include_bias(false)
     ///     .interaction_only(true)
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     pub fn builder() -> PolynomialFeaturesBuilder {
         PolynomialFeaturesBuilder::default()
@@ -195,11 +195,8 @@ pub struct PolynomialFeaturesBuilder {
 impl PolynomialFeaturesBuilder {
     /// Set the maximum degree of polynomial features. Required.
     ///
-    /// # Panics
-    ///
-    /// Panics if `degree` is `0`.
+    /// `degree == 0` is rejected at [`build`](PolynomialFeaturesBuilder::build) time.
     pub fn degree(mut self, degree: usize) -> Self {
-        assert!(degree >= 1, "degree must be >= 1, got {degree}");
         self.degree = Some(degree);
         self
     }
@@ -218,35 +215,47 @@ impl PolynomialFeaturesBuilder {
 
     /// Build the `PolynomialFeatures` instance.
     ///
-    /// # Panics
-    ///
-    /// Panics if `degree` was not set.
-    pub fn build(self) -> PolynomialFeatures {
-        let Some(degree) = self.degree else {
-            panic!(
+    /// Returns [`Error::InvalidInput`] if `degree` was not set or is `0`.
+    pub fn build(self) -> Result<PolynomialFeatures> {
+        let degree = self.degree.ok_or_else(|| {
+            Error::InvalidInput(
                 "PolynomialFeaturesBuilder: degree is required. Call .degree(n) before .build()."
-            );
-        };
-        PolynomialFeatures {
+                    .into(),
+            )
+        })?;
+        if degree == 0 {
+            return Err(Error::InvalidInput(
+                "PolynomialFeaturesBuilder: degree must be >= 1, got 0".into(),
+            ));
+        }
+        Ok(PolynomialFeatures {
             fitted: false,
             degree,
             interaction_only: self.interaction_only,
             include_bias: self.include_bias,
             input_columns: None,
-        }
+        })
     }
 }
 
 impl Default for PolynomialFeatures {
     fn default() -> Self {
-        Self::new(2)
+        // `new(2)` always succeeds; construct directly to avoid unwrapping a
+        // `Result` in `Default::default`.
+        Self {
+            fitted: false,
+            degree: 2,
+            interaction_only: false,
+            include_bias: true,
+            input_columns: None,
+        }
     }
 }
 
-impl Fit<DataFrame, DataFrame> for PolynomialFeatures {
+impl Fit<DataFrame> for PolynomialFeatures {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if x.height() == 0 || x.width() == 0 {
             return Err(Error::InvalidInput(
                 "PolynomialFeatures.fit received an empty DataFrame (0 rows or 0 columns).".into(),
@@ -385,11 +394,10 @@ mod tests {
 
     #[test]
     fn test_polynomial_features_fit_transform() {
-        let mut pf = PolynomialFeatures::new(2).include_bias(true);
+        let mut pf = PolynomialFeatures::new(2).unwrap().include_bias(true);
         let df = make_test_df();
-        let y = df.clone();
 
-        pf.fit(df.clone(), y).unwrap();
+        pf.fit(df.clone()).unwrap();
         let result = pf.transform(df).unwrap();
 
         assert_eq!(result.width(), 6);
@@ -398,11 +406,10 @@ mod tests {
 
     #[test]
     fn test_polynomial_features_no_bias() {
-        let mut pf = PolynomialFeatures::new(2).include_bias(false);
+        let mut pf = PolynomialFeatures::new(2).unwrap().include_bias(false);
         let df = make_test_df();
-        let y = df.clone();
 
-        pf.fit(df.clone(), y).unwrap();
+        pf.fit(df.clone()).unwrap();
         let result = pf.transform(df).unwrap();
 
         assert_eq!(result.width(), 5);
@@ -411,12 +418,12 @@ mod tests {
     #[test]
     fn test_polynomial_features_interaction_only() {
         let mut pf = PolynomialFeatures::new(2)
+            .unwrap()
             .include_bias(false)
             .interaction_only(true);
         let df = make_test_df();
-        let y = df.clone();
 
-        pf.fit(df.clone(), y).unwrap();
+        pf.fit(df.clone()).unwrap();
         let result = pf.transform(df).unwrap();
 
         assert_eq!(result.width(), 1);

--- a/src/preprocessing/polynomial_features.rs
+++ b/src/preprocessing/polynomial_features.rs
@@ -8,17 +8,35 @@ use crate::traits::{Error, Fit, Result, Transform};
 use crate::util::require_f64_columns;
 use polars::prelude::*;
 
-fn series_pow(s: &Series, exp: usize) -> Series {
-    let ca = s.f64().expect("expected f64 series");
+fn series_pow(s: &Series, exp: usize) -> Result<Series> {
+    let ca = s.f64().map_err(|e| {
+        Error::Computation(format!(
+            "PolynomialFeatures: expected f64 series for column '{}'. {}",
+            s.name(),
+            e
+        ))
+    })?;
     let exp_f64 = exp as f64;
     let result: ChunkedArray<Float64Type> =
         ca.iter().map(|opt| opt.map(|v| v.powf(exp_f64))).collect();
-    result.into_series()
+    Ok(result.into_series())
 }
 
-fn series_mul(a: &Series, b: &Series) -> Series {
-    let ca_a = a.f64().expect("expected f64 series");
-    let ca_b = b.f64().expect("expected f64 series");
+fn series_mul(a: &Series, b: &Series) -> Result<Series> {
+    let ca_a = a.f64().map_err(|e| {
+        Error::Computation(format!(
+            "PolynomialFeatures: expected f64 series for column '{}'. {}",
+            a.name(),
+            e
+        ))
+    })?;
+    let ca_b = b.f64().map_err(|e| {
+        Error::Computation(format!(
+            "PolynomialFeatures: expected f64 series for column '{}'. {}",
+            b.name(),
+            e
+        ))
+    })?;
     let result: ChunkedArray<Float64Type> = ca_a
         .iter()
         .zip(ca_b.iter())
@@ -27,7 +45,7 @@ fn series_mul(a: &Series, b: &Series) -> Series {
             _ => None,
         })
         .collect();
-    result.into_series()
+    Ok(result.into_series())
 }
 
 /// Generate polynomial and interaction features.
@@ -204,9 +222,11 @@ impl PolynomialFeaturesBuilder {
     ///
     /// Panics if `degree` was not set.
     pub fn build(self) -> PolynomialFeatures {
-        let degree = self.degree.expect(
-            "PolynomialFeaturesBuilder: degree is required. Call .degree(n) before .build().",
-        );
+        let Some(degree) = self.degree else {
+            panic!(
+                "PolynomialFeaturesBuilder: degree is required. Call .degree(n) before .build()."
+            );
+        };
         PolynomialFeatures {
             fitted: false,
             degree,
@@ -250,7 +270,13 @@ impl Transform<DataFrame> for PolynomialFeatures {
                     .into(),
             ));
         }
-        let input_columns = self.input_columns.as_ref().unwrap();
+        let input_columns = self.input_columns.as_ref().ok_or_else(|| {
+            Error::NotFitted(
+                "PolynomialFeatures has not been fitted. \
+                 Call .fit(dataframe, target) before .transform()."
+                    .into(),
+            )
+        })?;
         let powers = Self::generate_powers(input_columns.len(), self.degree, self.interaction_only);
 
         let mut columns: Vec<Column> = Vec::new();
@@ -285,20 +311,26 @@ impl Transform<DataFrame> for PolynomialFeatures {
                     .clone();
 
                 if !has_terms {
-                    series_vec = if p > 1 {
-                        Some(series_pow(&orig_series, p))
+                    series_vec = Some(if p > 1 {
+                        series_pow(&orig_series, p)?
                     } else {
-                        Some(orig_series)
-                    };
+                        orig_series
+                    });
                     col_name = name.clone();
                     has_terms = true;
                 } else {
                     let powered = if p > 1 {
-                        series_pow(&orig_series, p)
+                        series_pow(&orig_series, p)?
                     } else {
                         orig_series
                     };
-                    series_vec = Some(series_mul(&series_vec.unwrap(), &powered));
+                    let prev = series_vec.as_ref().ok_or_else(|| {
+                        Error::Computation(
+                            "PolynomialFeatures: internal state error — series_vec unset before mul"
+                                .into(),
+                        )
+                    })?;
+                    series_vec = Some(series_mul(prev, &powered)?);
                     col_name.push('_');
                     col_name.push_str(name);
                 }

--- a/src/preprocessing/scaler.rs
+++ b/src/preprocessing/scaler.rs
@@ -20,11 +20,16 @@ use crate::util::{replace_f64_column, require_f64_columns};
 /// ```rust
 /// use featrs::preprocessing::scaler::StandardScaler;
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let col = Column::from(Series::new("x".into(), &[1.0_f64, 2.0, 3.0]));
+/// let df = DataFrame::new(3, vec![col])?;
 ///
 /// let mut scaler = StandardScaler::new();
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // scaler.fit(df.clone(), target)?;
-/// // let scaled = scaler.transform(df)?;
+/// scaler.fit(df.clone())?;
+/// let scaled = scaler.transform(df)?;
+/// assert_eq!(scaled.height(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct StandardScaler {
     fitted: bool,
@@ -185,11 +190,16 @@ impl Transform<DataFrame> for StandardScaler {
 /// ```rust
 /// use featrs::preprocessing::scaler::MinMaxScaler;
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let col = Column::from(Series::new("x".into(), &[1.0_f64, 2.0, 3.0]));
+/// let df = DataFrame::new(3, vec![col])?;
 ///
 /// let mut scaler = MinMaxScaler::new().feature_range((-1.0, 1.0));
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // scaler.fit(df.clone(), target)?;
-/// // let scaled = scaler.transform(df)?;
+/// scaler.fit(df.clone())?;
+/// let scaled = scaler.transform(df)?;
+/// assert_eq!(scaled.height(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct MinMaxScaler {
     fitted: bool,
@@ -326,11 +336,16 @@ impl Transform<DataFrame> for MinMaxScaler {
 /// ```rust
 /// use featrs::preprocessing::scaler::RobustScaler;
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let col = Column::from(Series::new("x".into(), &[1.0_f64, 2.0, 3.0]));
+/// let df = DataFrame::new(3, vec![col])?;
 ///
 /// let mut scaler = RobustScaler::new().with_centering(true);
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // scaler.fit(df.clone(), target)?;
-/// // let scaled = scaler.transform(df)?;
+/// scaler.fit(df.clone())?;
+/// let scaled = scaler.transform(df)?;
+/// assert_eq!(scaled.height(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct RobustScaler {
     fitted: bool,

--- a/src/preprocessing/scaler.rs
+++ b/src/preprocessing/scaler.rs
@@ -8,23 +8,7 @@
 use polars::prelude::*;
 
 use crate::traits::{Error, Fit, Result, Transform};
-
-fn numeric_f64_columns(df: &DataFrame) -> Vec<String> {
-    df.get_column_names()
-        .iter()
-        .filter_map(|name| {
-            if let Ok(s) = df.column(name) {
-                if s.dtype() == &DataType::Float64 {
-                    Some(name.to_string())
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        })
-        .collect()
-}
+use crate::util::{replace_f64_column, require_f64_columns};
 
 /// Standardize features by removing the mean and scaling to unit variance.
 ///
@@ -100,21 +84,7 @@ impl Fit<DataFrame, DataFrame> for StandardScaler {
             ));
         }
 
-        let col_names = numeric_f64_columns(&x);
-        if col_names.is_empty() {
-            let all_types: Vec<String> = x
-                .get_column_names()
-                .iter()
-                .filter_map(|n| x.column(n).ok().map(|c| format!("'{}' ({})", n, c.dtype())))
-                .collect();
-            return Err(Error::InvalidInput(format!(
-                "StandardScaler: no Float64 columns found. \
-                 This transformer only operates on f64 columns. \
-                 Available columns: [{}]. \
-                 Try casting non-f64 columns before scaling.",
-                all_types.join(", ")
-            )));
-        }
+        let col_names = require_f64_columns(&x, "StandardScaler")?;
 
         let mut params = Vec::with_capacity(col_names.len());
 
@@ -191,34 +161,9 @@ impl Transform<DataFrame> for StandardScaler {
         let mut out = x.clone();
 
         for p in params {
-            let s = out.column(&p.name).map_err(|e| {
-                Error::InvalidInput(format!(
-                    "StandardScaler.transform: column '{}' not found in input. \
-                     The scaler was fitted on columns {:?}. {}",
-                    p.name,
-                    params.iter().map(|p| &p.name).collect::<Vec<_>>(),
-                    e
-                ))
-            })?;
-
-            let ca = s.f64().map_err(|e| {
-                Error::InvalidInput(format!(
-                    "StandardScaler.transform: column '{}' has dtype {}; expected Float64. {}",
-                    p.name,
-                    s.dtype(),
-                    e
-                ))
-            })?;
-
-            let scaled: ChunkedArray<Float64Type> = ca
-                .iter()
-                .map(|opt_v| opt_v.map(|v| (v - p.mean) / p.std))
-                .collect();
-
-            out.replace(&p.name, scaled.into_series().into())
-                .map_err(|e| {
-                    Error::Computation(format!("failed to replace column '{}': {}", p.name, e))
-                })?;
+            let mean = p.mean;
+            let std = p.std;
+            replace_f64_column(&mut out, &p.name, "StandardScaler", |v| (v - mean) / std)?;
         }
 
         Ok(out)
@@ -286,19 +231,7 @@ impl Fit<DataFrame, DataFrame> for MinMaxScaler {
                     .into(),
             ));
         }
-        let col_names = numeric_f64_columns(&x);
-        if col_names.is_empty() {
-            let all_types: Vec<String> = x
-                .get_column_names()
-                .iter()
-                .filter_map(|n| x.column(n).ok().map(|c| format!("'{}' ({})", n, c.dtype())))
-                .collect();
-            return Err(Error::InvalidInput(format!(
-                "MinMaxScaler: no Float64 columns found. \
-                 Available columns: [{}]. Cast non-f64 columns first.",
-                all_types.join(", ")
-            )));
-        }
+        let col_names = require_f64_columns(&x, "MinMaxScaler")?;
         let r_min = self.feature_range.0;
         let r_max = self.feature_range.1;
         let mut params = Vec::new();
@@ -348,13 +281,11 @@ impl Transform<DataFrame> for MinMaxScaler {
         let mut out = x.clone();
 
         for p in self.params.as_ref().unwrap() {
-            let s = out.column(&p.name).unwrap();
-            let ca = s.f64().unwrap();
-            let scaled: ChunkedArray<Float64Type> = ca
-                .iter()
-                .map(|opt| opt.map(|v| (v - p.min) * p.scale + r_min))
-                .collect();
-            out.replace(&p.name, scaled.into_series().into()).unwrap();
+            let min = p.min;
+            let scale = p.scale;
+            replace_f64_column(&mut out, &p.name, "MinMaxScaler", |v| {
+                (v - min) * scale + r_min
+            })?;
         }
 
         Ok(out)
@@ -447,26 +378,14 @@ impl Fit<DataFrame, DataFrame> for RobustScaler {
                     .into(),
             ));
         }
-        let col_names = numeric_f64_columns(&x);
-        if col_names.is_empty() {
-            let all_types: Vec<String> = x
-                .get_column_names()
-                .iter()
-                .filter_map(|n| x.column(n).ok().map(|c| format!("'{}' ({})", n, c.dtype())))
-                .collect();
-            return Err(Error::InvalidInput(format!(
-                "RobustScaler: no Float64 columns found. \
-                 Available columns: [{}]. Cast non-f64 columns first.",
-                all_types.join(", ")
-            )));
-        }
+        let col_names = require_f64_columns(&x, "RobustScaler")?;
         let mut params = Vec::new();
 
         for name in &col_names {
             let s = x.column(name.as_str()).unwrap();
             let ca = s.f64().unwrap();
             let mut vals: Vec<f64> = ca.iter().flatten().collect();
-            vals.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            vals.sort_by(|a, b| a.total_cmp(b));
 
             let median = percentile_sorted(&vals, 50.0);
             let q1 = percentile_sorted(&vals, 25.0);
@@ -508,13 +427,9 @@ impl Transform<DataFrame> for RobustScaler {
         let mut out = x.clone();
 
         for p in self.params.as_ref().unwrap() {
-            let s = out.column(&p.name).unwrap();
-            let ca = s.f64().unwrap();
-            let scaled: ChunkedArray<Float64Type> = ca
-                .iter()
-                .map(|opt| opt.map(|v| (v - p.center) / p.scale))
-                .collect();
-            out.replace(&p.name, scaled.into_series().into()).unwrap();
+            let center = p.center;
+            let scale = p.scale;
+            replace_f64_column(&mut out, &p.name, "RobustScaler", |v| (v - center) / scale)?;
         }
 
         Ok(out)
@@ -599,5 +514,17 @@ mod tests {
         let df = make_test_df();
         let result = scaler.transform(df);
         assert!(result.is_err());
+    }
+
+    /// Regression: `partial_cmp().unwrap()` panicked when a column contained NaN.
+    /// `total_cmp` sorts NaN deterministically without panicking.
+    #[test]
+    fn test_robust_scaler_with_nan_does_not_panic() {
+        let a = Column::from(Series::new("a".into(), &[1.0f64, f64::NAN, 5.0, 3.0]));
+        let df = DataFrame::new(4, vec![a]).unwrap();
+        let mut scaler = RobustScaler::new();
+        // fit must not panic on the NaN-bearing sort.
+        scaler.fit(df.clone(), df.clone()).unwrap();
+        let _ = scaler.transform(df).unwrap();
     }
 }

--- a/src/preprocessing/scaler.rs
+++ b/src/preprocessing/scaler.rs
@@ -71,10 +71,10 @@ impl Default for StandardScaler {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for StandardScaler {
+impl Fit<DataFrame> for StandardScaler {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         let n_cols = x.width();
         if x.height() == 0 || n_cols == 0 {
             return Err(Error::InvalidInput(
@@ -226,10 +226,10 @@ impl Default for MinMaxScaler {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for MinMaxScaler {
+impl Fit<DataFrame> for MinMaxScaler {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if x.height() == 0 || x.width() == 0 {
             return Err(Error::InvalidInput(
                 "MinMaxScaler.fit received an empty DataFrame (0 rows or 0 columns). \
@@ -391,10 +391,10 @@ fn percentile_sorted(sorted: &[f64], p: f64) -> f64 {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for RobustScaler {
+impl Fit<DataFrame> for RobustScaler {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if x.height() == 0 || x.width() == 0 {
             return Err(Error::InvalidInput(
                 "RobustScaler.fit received an empty DataFrame (0 rows or 0 columns). \
@@ -493,9 +493,8 @@ mod tests {
     fn test_standard_scaler_fit_transform() {
         let mut scaler = StandardScaler::new();
         let df = make_test_df();
-        let y = df.clone();
 
-        scaler.fit(df.clone(), y).unwrap();
+        scaler.fit(df.clone()).unwrap();
         let result = scaler.transform(df).unwrap();
 
         let scaled_a = result.column("a").unwrap().f64().unwrap();
@@ -510,9 +509,8 @@ mod tests {
     fn test_min_max_scaler() {
         let mut scaler = MinMaxScaler::new();
         let df = make_test_df();
-        let y = df.clone();
 
-        scaler.fit(df.clone(), y).unwrap();
+        scaler.fit(df.clone()).unwrap();
         let result = scaler.transform(df).unwrap();
 
         let vals: Vec<f64> = result
@@ -532,9 +530,8 @@ mod tests {
     fn test_robust_scaler() {
         let mut scaler = RobustScaler::new();
         let df = make_test_df();
-        let y = df.clone();
 
-        scaler.fit(df.clone(), y).unwrap();
+        scaler.fit(df.clone()).unwrap();
         let result = scaler.transform(df).unwrap();
 
         let vals: Vec<f64> = result
@@ -566,7 +563,7 @@ mod tests {
         let df = DataFrame::new(4, vec![a]).unwrap();
         let mut scaler = RobustScaler::new();
         // fit must not panic on the NaN-bearing sort.
-        scaler.fit(df.clone(), df.clone()).unwrap();
+        scaler.fit(df.clone()).unwrap();
         let _ = scaler.transform(df).unwrap();
     }
 }

--- a/src/preprocessing/scaler.rs
+++ b/src/preprocessing/scaler.rs
@@ -157,7 +157,13 @@ impl Transform<DataFrame> for StandardScaler {
             ));
         }
 
-        let params = self.params.as_ref().unwrap();
+        let params = self.params.as_ref().ok_or_else(|| {
+            Error::NotFitted(
+                "StandardScaler has not been fitted. \
+                 Call .fit(dataframe, target) before .transform()."
+                    .into(),
+            )
+        })?;
         let mut out = x.clone();
 
         for p in params {
@@ -237,8 +243,20 @@ impl Fit<DataFrame, DataFrame> for MinMaxScaler {
         let mut params = Vec::new();
 
         for name in &col_names {
-            let s = x.column(name.as_str()).unwrap();
-            let ca = s.f64().unwrap();
+            let s = x.column(name.as_str()).map_err(|e| {
+                Error::InvalidInput(format!(
+                    "MinMaxScaler.fit: column '{}' not found. {}",
+                    name, e
+                ))
+            })?;
+            let ca = s.f64().map_err(|e| {
+                Error::InvalidInput(format!(
+                    "MinMaxScaler.fit: column '{}' has dtype {}; expected Float64. {}",
+                    name,
+                    s.dtype(),
+                    e
+                ))
+            })?;
             let vals: Vec<f64> = ca.iter().flatten().collect();
             let col_min = vals.iter().cloned().fold(f64::NAN, f64::min);
             let col_max = vals.iter().cloned().fold(f64::NAN, f64::max);
@@ -280,7 +298,13 @@ impl Transform<DataFrame> for MinMaxScaler {
         let r_min = self.feature_range.0;
         let mut out = x.clone();
 
-        for p in self.params.as_ref().unwrap() {
+        for p in self.params.as_ref().ok_or_else(|| {
+            Error::NotFitted(
+                "MinMaxScaler has not been fitted. \
+                 Call .fit(dataframe, target) before .transform()."
+                    .into(),
+            )
+        })? {
             let min = p.min;
             let scale = p.scale;
             replace_f64_column(&mut out, &p.name, "MinMaxScaler", |v| {
@@ -382,8 +406,20 @@ impl Fit<DataFrame, DataFrame> for RobustScaler {
         let mut params = Vec::new();
 
         for name in &col_names {
-            let s = x.column(name.as_str()).unwrap();
-            let ca = s.f64().unwrap();
+            let s = x.column(name.as_str()).map_err(|e| {
+                Error::InvalidInput(format!(
+                    "RobustScaler.fit: column '{}' not found. {}",
+                    name, e
+                ))
+            })?;
+            let ca = s.f64().map_err(|e| {
+                Error::InvalidInput(format!(
+                    "RobustScaler.fit: column '{}' has dtype {}; expected Float64. {}",
+                    name,
+                    s.dtype(),
+                    e
+                ))
+            })?;
             let mut vals: Vec<f64> = ca.iter().flatten().collect();
             vals.sort_by(|a, b| a.total_cmp(b));
 
@@ -426,7 +462,13 @@ impl Transform<DataFrame> for RobustScaler {
         }
         let mut out = x.clone();
 
-        for p in self.params.as_ref().unwrap() {
+        for p in self.params.as_ref().ok_or_else(|| {
+            Error::NotFitted(
+                "RobustScaler has not been fitted. \
+                 Call .fit(dataframe, target) before .transform()."
+                    .into(),
+            )
+        })? {
             let center = p.center;
             let scale = p.scale;
             replace_f64_column(&mut out, &p.name, "RobustScaler", |v| (v - center) / scale)?;

--- a/src/time_series/cyclical.rs
+++ b/src/time_series/cyclical.rs
@@ -52,10 +52,10 @@ impl CyclicalEncoder {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for CyclicalEncoder {
+impl Fit<DataFrame> for CyclicalEncoder {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         for (col, _) in &self.columns {
             if x.column(col.as_str()).is_err() {
                 return Err(Error::InvalidInput(format!(
@@ -137,9 +137,8 @@ mod tests {
         let vals = Column::from(Series::new("hour".into(), &[0.0f64, 6.0, 12.0, 18.0]));
         let df = DataFrame::new(4, vec![vals]).unwrap();
         let mut enc = CyclicalEncoder::new(&["hour"], 24);
-        let y = df.clone();
 
-        enc.fit(df.clone(), y).unwrap();
+        enc.fit(df.clone()).unwrap();
         let result = enc.transform(df).unwrap();
 
         assert_eq!(result.width(), 3); // hour, hour_sin, hour_cos

--- a/src/time_series/cyclical.rs
+++ b/src/time_series/cyclical.rs
@@ -80,9 +80,20 @@ impl Transform<DataFrame> for CyclicalEncoder {
         let two_pi = 2.0 * std::f64::consts::PI;
 
         for (col, period) in &self.columns {
-            let s = out.column(col.as_str()).unwrap().clone();
-            let ca = s.f64().map_err(|_| {
-                Error::InvalidInput(format!("CyclicalEncoder: column '{}' must be f64.", col))
+            let s = out.column(col.as_str()).map_err(|e| {
+                Error::InvalidInput(format!(
+                    "CyclicalEncoder.transform: column '{}' not found. {}",
+                    col, e
+                ))
+            })?;
+            let s = s.clone();
+            let ca = s.f64().map_err(|e| {
+                Error::InvalidInput(format!(
+                    "CyclicalEncoder.transform: column '{}' has dtype {}; expected Float64. {}",
+                    col,
+                    s.dtype(),
+                    e
+                ))
             })?;
 
             let sin_vals: ChunkedArray<Float64Type> = ca

--- a/src/time_series/cyclical.rs
+++ b/src/time_series/cyclical.rs
@@ -29,6 +29,8 @@ pub struct CyclicalEncoder {
 }
 
 impl CyclicalEncoder {
+    /// Create an encoder that maps each column to `(sin, cos)` using a single
+    /// shared integer period (e.g. `24` for hours, `12` for months).
     pub fn new(columns: &[&str], period: usize) -> Self {
         let period_f = period as f64;
         Self {
@@ -37,6 +39,8 @@ impl CyclicalEncoder {
         }
     }
 
+    /// Create an encoder where each column gets its own integer period, given as
+    /// `(column_name, period)` pairs.
     pub fn with_periods(columns: &[(&str, usize)]) -> Self {
         Self {
             fitted: false,

--- a/src/time_series/cyclical.rs
+++ b/src/time_series/cyclical.rs
@@ -17,11 +17,16 @@ use polars::prelude::*;
 /// ```rust
 /// use featrs::time_series::cyclical::CyclicalEncoder;
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let col = Column::from(Series::new("hour".into(), &[0.0_f64, 6.0, 12.0, 18.0]));
+/// let df = DataFrame::new(4, vec![col])?;
 ///
 /// let mut enc = CyclicalEncoder::new(&["hour"], 24);
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // enc.fit(df.clone(), target)?;
-/// // let encoded = enc.transform(df)?;
+/// enc.fit(df.clone())?;
+/// let encoded = enc.transform(df)?;
+/// assert_eq!(encoded.height(), 4);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct CyclicalEncoder {
     fitted: bool,

--- a/src/time_series/diff.rs
+++ b/src/time_series/diff.rs
@@ -48,10 +48,10 @@ impl Difference {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for Difference {
+impl Fit<DataFrame> for Difference {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if self.columns.is_empty() {
             return Err(Error::InvalidInput(
                 "Difference: at least one column is required.".into(),
@@ -141,9 +141,8 @@ mod tests {
         let vals = Column::from(Series::new("x".into(), &[10.0f64, 20.0, 30.0, 40.0]));
         let df = DataFrame::new(4, vec![vals]).unwrap();
         let mut d = Difference::diff(&["x"], 1);
-        let y = df.clone();
 
-        d.fit(df.clone(), y).unwrap();
+        d.fit(df.clone()).unwrap();
         let result = d.transform(df).unwrap();
 
         let diffed = result.column("x_diff_1").unwrap().f64().unwrap();
@@ -157,9 +156,8 @@ mod tests {
         let vals = Column::from(Series::new("x".into(), &[100.0f64, 110.0, 121.0]));
         let df = DataFrame::new(3, vec![vals]).unwrap();
         let mut d = Difference::pct_change(&["x"], 1);
-        let y = df.clone();
 
-        d.fit(df.clone(), y).unwrap();
+        d.fit(df.clone()).unwrap();
         let result = d.transform(df).unwrap();
 
         let pct = result.column("x_pct_1").unwrap().f64().unwrap();

--- a/src/time_series/diff.rs
+++ b/src/time_series/diff.rs
@@ -80,7 +80,13 @@ impl Transform<DataFrame> for Difference {
         let mut out = x.clone();
 
         for col in &self.columns {
-            let s = out.column(col.as_str()).unwrap().clone();
+            let s = out.column(col.as_str()).map_err(|e| {
+                Error::InvalidInput(format!(
+                    "Difference.transform: column '{}' not found. {}",
+                    col, e
+                ))
+            })?;
+            let s = s.clone();
 
             let suffix = if self.pct_change { "pct" } else { "diff" };
             let col_name = format!("{}_{}_{}", col, suffix, self.period);

--- a/src/time_series/diff.rs
+++ b/src/time_series/diff.rs
@@ -26,6 +26,8 @@ pub struct Difference {
 }
 
 impl Difference {
+    /// Create a new differencer for `columns` over `period` lag.
+    /// If `pct_change` is `true`, compute percentage change instead of absolute difference.
     pub fn new(columns: &[&str], period: i64, pct_change: bool) -> Self {
         Self {
             fitted: false,

--- a/src/time_series/diff.rs
+++ b/src/time_series/diff.rs
@@ -12,11 +12,16 @@ use polars::prelude::*;
 /// ```rust
 /// use featrs::time_series::diff::Difference;
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let col = Column::from(Series::new("value".into(), &[10.0_f64, 20.0, 30.0, 40.0]));
+/// let df = DataFrame::new(4, vec![col])?;
 ///
 /// let mut d = Difference::new(&["value"], 1, false);
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // d.fit(df.clone(), target)?;
-/// // let diffed = d.transform(df)?;
+/// d.fit(df.clone())?;
+/// let diffed = d.transform(df)?;
+/// assert_eq!(diffed.height(), 4);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct Difference {
     fitted: bool,

--- a/src/time_series/lag.rs
+++ b/src/time_series/lag.rs
@@ -83,7 +83,13 @@ impl Transform<DataFrame> for Lagger {
         let mut out = x.clone();
 
         for col in &self.columns {
-            let s = out.column(col.as_str()).unwrap().clone();
+            let s = out.column(col.as_str()).map_err(|e| {
+                Error::InvalidInput(format!(
+                    "Lagger.transform: column '{}' not found. {}",
+                    col, e
+                ))
+            })?;
+            let s = s.clone();
             for &period in &self.periods {
                 let shifted = s.shift(period);
                 let lag_name = format!("{}_lag_{}", col, period);

--- a/src/time_series/lag.rs
+++ b/src/time_series/lag.rs
@@ -42,10 +42,10 @@ impl Lagger {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for Lagger {
+impl Fit<DataFrame> for Lagger {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if self.columns.is_empty() {
             return Err(Error::InvalidInput(
                 "Lagger: at least one column name is required.".into(),
@@ -111,9 +111,8 @@ mod tests {
         let vals = Column::from(Series::new("x".into(), &[1.0f64, 2.0, 3.0, 4.0, 5.0]));
         let df = DataFrame::new(5, vec![vals]).unwrap();
         let mut lagger = Lagger::new(&["x"], &[1, 2]);
-        let y = df.clone();
 
-        lagger.fit(df.clone(), y).unwrap();
+        lagger.fit(df.clone()).unwrap();
         let result = lagger.transform(df).unwrap();
 
         assert_eq!(result.width(), 3); // x, x_lag_1, x_lag_2

--- a/src/time_series/lag.rs
+++ b/src/time_series/lag.rs
@@ -16,11 +16,16 @@ use polars::prelude::*;
 /// ```rust
 /// use featrs::time_series::lag::Lagger;
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let col = Column::from(Series::new("value".into(), &[1.0_f64, 2.0, 3.0, 4.0, 5.0]));
+/// let df = DataFrame::new(5, vec![col])?;
 ///
 /// let mut lagger = Lagger::new(&["value"], &[1, 3, 7]);
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // lagger.fit(df.clone(), target)?;
-/// // let lagged = lagger.transform(df)?;
+/// lagger.fit(df.clone())?;
+/// let lagged = lagger.transform(df)?;
+/// assert_eq!(lagged.height(), 5);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct Lagger {
     fitted: bool,

--- a/src/time_series/rolling.rs
+++ b/src/time_series/rolling.rs
@@ -28,11 +28,16 @@ pub enum RollingFn {
 /// ```rust
 /// use featrs::time_series::rolling::{RollingAggregator, RollingFn};
 /// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
 ///
-/// let mut r = RollingAggregator::new(&["value"], 7, RollingFn::Mean);
-/// # let df = polars::prelude::DataFrame::new(0usize, vec![]).unwrap();
-/// // r.fit(df.clone(), target)?;
-/// // let rolled = r.transform(df)?;
+/// let col = Column::from(Series::new("value".into(), &[1.0_f64, 2.0, 3.0, 4.0, 5.0]));
+/// let df = DataFrame::new(5, vec![col])?;
+///
+/// let mut r = RollingAggregator::new(&["value"], 3, RollingFn::Mean);
+/// r.fit(df.clone())?;
+/// let rolled = r.transform(df)?;
+/// assert_eq!(rolled.height(), 5);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct RollingAggregator {
     fitted: bool,

--- a/src/time_series/rolling.rs
+++ b/src/time_series/rolling.rs
@@ -95,10 +95,10 @@ impl RollingAggregator {
     }
 }
 
-impl Fit<DataFrame, DataFrame> for RollingAggregator {
+impl Fit<DataFrame> for RollingAggregator {
     type Output = ();
 
-    fn fit(&mut self, x: DataFrame, _y: DataFrame) -> Result<()> {
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
         if self.columns.is_empty() {
             return Err(Error::InvalidInput(
                 "RollingAggregator: at least one column is required.".into(),
@@ -170,9 +170,8 @@ mod tests {
         let vals = Column::from(Series::new("x".into(), &[1.0f64, 2.0, 3.0, 4.0, 5.0]));
         let df = DataFrame::new(5, vec![vals]).unwrap();
         let mut r = RollingAggregator::new(&["x"], 3, RollingFn::Mean);
-        let y = df.clone();
 
-        r.fit(df.clone(), y).unwrap();
+        r.fit(df.clone()).unwrap();
         let result = r.transform(df).unwrap();
 
         assert_eq!(result.width(), 2);

--- a/src/time_series/rolling.rs
+++ b/src/time_series/rolling.rs
@@ -135,7 +135,12 @@ impl Transform<DataFrame> for RollingAggregator {
         for col in &self.columns {
             let s = out
                 .column(col.as_str())
-                .unwrap()
+                .map_err(|e| {
+                    Error::InvalidInput(format!(
+                        "RollingAggregator.transform: column '{}' not found. {}",
+                        col, e
+                    ))
+                })?
                 .as_materialized_series()
                 .clone();
             let fn_name = match self.function {

--- a/src/time_series/rolling.rs
+++ b/src/time_series/rolling.rs
@@ -9,10 +9,15 @@ use polars::prelude::*;
 /// Rolling window function to apply.
 #[derive(Clone, Copy)]
 pub enum RollingFn {
+    /// Rolling mean over the window.
     Mean,
+    /// Rolling (sample) standard deviation over the window.
     Std,
+    /// Rolling minimum over the window.
     Min,
+    /// Rolling maximum over the window.
     Max,
+    /// Rolling sum over the window.
     Sum,
 }
 
@@ -37,6 +42,8 @@ pub struct RollingAggregator {
 }
 
 impl RollingAggregator {
+    /// Create a new rolling aggregator for `columns` over a `window_size`-row
+    /// window, applying `function` (e.g. [`RollingFn::Mean`]).
     pub fn new(columns: &[&str], window_size: usize, function: RollingFn) -> Self {
         Self {
             fitted: false,

--- a/src/traits/missing_indicator.rs
+++ b/src/traits/missing_indicator.rs
@@ -87,7 +87,12 @@ impl Transform<DataFrame> for MissingIndicator {
         for col in &self.columns {
             let s = out
                 .column(col.as_str())
-                .unwrap()
+                .map_err(|e| {
+                    Error::InvalidInput(format!(
+                        "MissingIndicator.transform: column '{}' not found. {}",
+                        col, e
+                    ))
+                })?
                 .as_materialized_series()
                 .clone();
             let has_missing = s.null_count() > 0;

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,10 +1,18 @@
 //! Core traits and error types for the featrs library.
 //!
-//! The library is built around three traits that mirror the scikit-learn API:
+//! The library is built around four traits that mirror the scikit-learn API:
 //!
-//! - [`Fit`] — learn parameters from data (`fit`)
+//! - [`Fit`] — learn parameters from unsupervised data (`fit(X)`)
+//! - [`FitSupervised`] — learn parameters from data plus a target (`fit(X, y)`)
 //! - [`Transform`] — apply a learned transformation (`transform`)
-//! - [`FitTransform`] — convenience blanket trait for types that implement both
+//! - [`FitTransform`] — convenience trait that provides a default
+//!   `fit_transform(X)` for any type implementing both [`Fit`] and [`Transform`]
+//!
+//! Unsupervised transformers (scalers, encoders, imputers, …) implement
+//! [`Fit`]; the few supervised ones (e.g. `SelectKBest`) implement
+//! [`FitSupervised`] instead. This mirrors scikit-learn's split between
+//! `fit(X)` and `fit(X, y)`, so callers no longer pass a dummy target to
+//! unsupervised transformers.
 //!
 //! # Errors
 //!
@@ -13,8 +21,6 @@
 //! - [`Error::InvalidInput`] — wrong dimensions, types, or empty data
 //! - [`Error::NotFitted`] — `transform` called before `fit`
 //! - [`Error::Computation`] — numerical issues (zero variance, singular matrices, etc.)
-
-pub mod missing_indicator;
 
 use thiserror::Error;
 
@@ -37,10 +43,11 @@ pub enum Error {
 /// Convenience alias for `std::result::Result<T, Error>`.
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Learn parameters from data.
+/// Learn parameters from unsupervised data.
 ///
-/// `X` is the feature data (e.g. `DataFrame`).
-/// `Y` is the target data (defaults to `X` for unsupervised transformers).
+/// `X` is the feature data (e.g. `DataFrame`). Implement this trait for
+/// transformers that do not need a target (scalers, encoders, imputers, …).
+/// Supervised transformers implement [`FitSupervised`] instead.
 ///
 /// # Example
 ///
@@ -49,14 +56,32 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// # use featrs::traits::Result;
 /// # use polars::prelude::*;
 ///
-/// // Every transformer implements Fit. The fitted parameters are stored
-/// // on the transformer itself.
+/// // Unsupervised transformers implement Fit. The fitted parameters are
+/// // stored on the transformer itself.
 /// ```
-pub trait Fit<X, Y = X> {
+pub trait Fit<X> {
     /// The type returned by `fit`. Usually `()`.
     type Output;
 
     /// Fit the transformer to the data.
+    ///
+    /// After calling `fit`, the transformer stores the learned parameters
+    /// internally. Calling `transform` before `fit` returns
+    /// [`Error::NotFitted`].
+    fn fit(&mut self, x: X) -> Result<Self::Output>;
+}
+
+/// Learn parameters from data plus a supervised target.
+///
+/// `X` is the feature data and `Y` is the target data (both typically
+/// `DataFrame`). Implement this trait for transformers that need a target,
+/// such as [`SelectKBest`](crate::feature_selection::SelectKBest). Unsupervised
+/// transformers implement [`Fit`] instead.
+pub trait FitSupervised<X, Y> {
+    /// The type returned by `fit`. Usually `()`.
+    type Output;
+
+    /// Fit the transformer to the data and target.
     ///
     /// After calling `fit`, the transformer stores the learned parameters
     /// internally. Calling `transform` before `fit` returns
@@ -89,9 +114,24 @@ pub trait Transform<X> {
 
 /// Convenience trait for types that implement both [`Fit`] and [`Transform`].
 ///
-/// This trait is automatically implemented for any type that satisfies
-/// both bounds. It is used to enable type erasure with
+/// Automatically implemented for any type satisfying both bounds. Provides a
+/// default [`fit_transform`](FitTransform::fit_transform) equivalent to
+/// `fit(X)` followed by `transform(X)`; types may override it with an optimized
+/// single-pass implementation. Also enables type erasure via
 /// [`Box<dyn DataFrameTransformer>`](crate::pipeline::DataFrameTransformer).
-pub trait FitTransform<X, Y = X>: Fit<X, Y> + Transform<X> {}
+pub trait FitTransform<X>: Fit<X> + Transform<X> {
+    /// Fit to `x`, then transform `x`, returning the transformed output.
+    ///
+    /// Default implementation clones `x` so it can be both fit on and
+    /// transformed; override for a single-pass implementation when `X` need
+    /// not be cloned.
+    fn fit_transform(&mut self, x: X) -> Result<<Self as Transform<X>>::Output>
+    where
+        X: Clone,
+    {
+        self.fit(x.clone())?;
+        self.transform(x)
+    }
+}
 
-impl<T, X, Y> FitTransform<X, Y> for T where T: Fit<X, Y> + Transform<X> {}
+impl<T, X> FitTransform<X> for T where T: Fit<X> + Transform<X> {}

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -52,12 +52,18 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// # Example
 ///
 /// ```rust
-/// use featrs::traits::Fit;
-/// # use featrs::traits::Result;
-/// # use polars::prelude::*;
+/// use featrs::preprocessing::scaler::StandardScaler;
+/// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
 ///
-/// // Unsupervised transformers implement Fit. The fitted parameters are
-/// // stored on the transformer itself.
+/// let col = Column::from(Series::new("x".into(), &[1.0_f64, 2.0, 3.0]));
+/// let df = DataFrame::new(3, vec![col])?;
+///
+/// let mut scaler = StandardScaler::new();
+/// scaler.fit(df.clone())?;
+/// let scaled = scaler.transform(df)?;
+/// assert_eq!(scaled.height(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub trait Fit<X> {
     /// The type returned by `fit`. Usually `()`.
@@ -97,10 +103,18 @@ pub trait FitSupervised<X, Y> {
 /// # Example
 ///
 /// ```rust
-/// use featrs::traits::Transform;
-/// # use polars::prelude::*;
+/// use featrs::preprocessing::scaler::StandardScaler;
+/// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
 ///
-/// // After fitting, call transform to apply the transformation.
+/// let col = Column::from(Series::new("x".into(), &[1.0_f64, 2.0, 3.0]));
+/// let df = DataFrame::new(3, vec![col])?;
+///
+/// let mut scaler = StandardScaler::new();
+/// scaler.fit(df.clone())?;
+/// let scaled = scaler.transform(df)?;
+/// assert_eq!(scaled.width(), 1);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub trait Transform<X> {
     /// The type of the transformed output.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,78 @@
+//! Shared helpers for transformers operating on `Float64` columns.
+//!
+//! These utilities exist to keep the per-transformer code free of duplicated
+//! column-discovery, validation, and in-place replacement boilerplate.
+
+use polars::prelude::{ChunkedArray, DataFrame, DataType, Float64Type, IntoSeries};
+
+use crate::traits::{Error, Result};
+
+/// Return the names of all `Float64` columns in `df`, in frame order.
+///
+/// Non-`Float64` columns are silently skipped. Transformers that need to
+/// surface this as an error should use [`require_f64_columns`] instead.
+pub fn numeric_f64_columns(df: &DataFrame) -> Vec<String> {
+    df.get_column_names()
+        .iter()
+        .filter_map(|name| {
+            df.column(name)
+                .ok()
+                .filter(|s| s.dtype() == &DataType::Float64)
+                .map(|_| name.to_string())
+        })
+        .collect()
+}
+
+/// Return the names of all `Float64` columns, or an `InvalidInput` error that
+/// lists every column and its dtype when none are `Float64`.
+///
+/// `who` is the transformer name used in the error message
+/// (e.g. `"StandardScaler"`), so failures are easy to trace back to the
+/// transformer that produced them.
+pub fn require_f64_columns(df: &DataFrame, who: &str) -> Result<Vec<String>> {
+    let cols = numeric_f64_columns(df);
+    if cols.is_empty() {
+        let all_types: Vec<String> = df
+            .get_column_names()
+            .iter()
+            .filter_map(|n| df.column(n).ok().map(|c| format!("'{n}' ({})", c.dtype())))
+            .collect();
+        return Err(Error::InvalidInput(format!(
+            "{who}: no Float64 columns found. This transformer only operates on f64 columns. \
+             Available columns: [{}]. Cast non-f64 columns before fitting.",
+            all_types.join(", ")
+        )));
+    }
+    Ok(cols)
+}
+
+/// Apply a per-element f64 transform to a single named column of `df`,
+/// replacing the column in place.
+///
+/// `f` maps each non-null `f64` value to its replacement; nulls are preserved.
+/// `who` names the calling transformer for error context.
+///
+/// This collapses the `column(name).unwrap()` → `f64().unwrap()` →
+/// `replace(...).unwrap()` boilerplate that would otherwise be duplicated in
+/// every f64-based transformer's `transform` implementation.
+pub fn replace_f64_column<F>(df: &mut DataFrame, name: &str, who: &str, f: F) -> Result<()>
+where
+    F: Fn(f64) -> f64,
+{
+    let s = df.column(name).map_err(|e| {
+        Error::InvalidInput(format!("{who}.transform: column '{name}' not found. {e}"))
+    })?;
+    let ca = s.f64().map_err(|e| {
+        Error::InvalidInput(format!(
+            "{who}.transform: column '{name}' has dtype {}; expected Float64. {e}",
+            s.dtype()
+        ))
+    })?;
+    let mapped: ChunkedArray<Float64Type> = ca.iter().map(|opt| opt.map(&f)).collect();
+    df.replace(name, mapped.into_series().into()).map_err(|e| {
+        Error::Computation(format!(
+            "{who}.transform: failed to replace column '{name}'. {e}"
+        ))
+    })?;
+    Ok(())
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10,39 +10,38 @@ fn test_end_to_end_pipeline() {
         &[10.0f64, 20.0, 30.0, 40.0, 50.0],
     ));
     let t = Column::from(Series::new("target".into(), &[0.0f64, 0.0, 0.0, 1.0, 1.0]));
-    let df = DataFrame::new(5, vec![a, b, t.clone()]).unwrap();
+    let df = DataFrame::new(5, vec![a, b, t]).unwrap();
     let features = df.select(["feat_a", "feat_b"]).unwrap();
-    let target = DataFrame::new(5, vec![t]).unwrap();
 
     // StandardScaler
     use featrs::traits::{Fit, Transform};
     let mut scaler = featrs::preprocessing::scaler::StandardScaler::new();
-    scaler.fit(features.clone(), target.clone()).unwrap();
+    scaler.fit(features.clone()).unwrap();
     let scaled = scaler.transform(features.clone()).unwrap();
     assert_eq!(scaled.width(), 2);
     assert_eq!(scaled.height(), 5);
 
     // MinMaxScaler
     let mut minmax = featrs::preprocessing::scaler::MinMaxScaler::new();
-    minmax.fit(features.clone(), target.clone()).unwrap();
+    minmax.fit(features.clone()).unwrap();
     let mm_scaled = minmax.transform(features.clone()).unwrap();
     assert_eq!(mm_scaled.width(), 2);
 
     // Binarizer
     let mut binarizer = featrs::preprocessing::binarizer::Binarizer::new(2.5);
-    binarizer.fit(features.clone(), target.clone()).unwrap();
+    binarizer.fit(features.clone()).unwrap();
     let bin = binarizer.transform(features.clone()).unwrap();
     assert_eq!(bin.width(), 2);
 
     // Normalizer
     let mut normalizer = featrs::preprocessing::normalizer::Normalizer::l2();
-    normalizer.fit(features.clone(), target.clone()).unwrap();
+    normalizer.fit(features.clone()).unwrap();
     let norm = normalizer.transform(features.clone()).unwrap();
     assert_eq!(norm.width(), 2);
 
     // PolynomialFeatures
-    let mut poly = featrs::preprocessing::polynomial_features::PolynomialFeatures::new(2);
-    poly.fit(features.clone(), target.clone()).unwrap();
+    let mut poly = featrs::preprocessing::polynomial_features::PolynomialFeatures::new(2).unwrap();
+    poly.fit(features.clone()).unwrap();
     let pf = poly.transform(features).unwrap();
     // bias + feat_a + feat_b + feat_a^2 + feat_a*feat_b + feat_b^2
     assert_eq!(pf.width(), 6); // bias(1) + degree1(2) + degree2(3)
@@ -51,7 +50,7 @@ fn test_end_to_end_pipeline() {
 
 #[test]
 fn test_end_to_end_feature_selection() {
-    use featrs::traits::{Fit, Transform};
+    use featrs::traits::{Fit, FitSupervised, Transform};
 
     let a = Column::from(Series::new("const".into(), &[1.0f64, 1.0, 1.0, 1.0, 1.0]));
     let b = Column::from(Series::new(
@@ -65,7 +64,7 @@ fn test_end_to_end_feature_selection() {
 
     // VarianceThreshold
     let mut vt = featrs::feature_selection::VarianceThreshold::new(0.1);
-    vt.fit(features.clone(), target.clone()).unwrap();
+    vt.fit(features.clone()).unwrap();
     let filtered = vt.transform(features.clone()).unwrap();
     assert_eq!(filtered.width(), 1);
     assert_eq!(filtered.get_column_names()[0].as_str(), "signal");
@@ -93,20 +92,20 @@ fn test_end_to_end_encoders() {
 
     // OneHotEncoder
     let mut ohe = featrs::preprocessing::encoder::OneHotEncoder::new();
-    ohe.fit(df.clone(), df.clone()).unwrap();
+    ohe.fit(df.clone()).unwrap();
     let encoded = ohe.transform(df.clone()).unwrap();
     assert_eq!(encoded.width(), 6); // 3 + 3 categories
 
     // LabelEncoder
     let colors = df.select(["color"]).unwrap();
     let mut le = featrs::preprocessing::encoder::LabelEncoder::new();
-    le.fit(colors.clone(), colors.clone()).unwrap();
+    le.fit(colors.clone()).unwrap();
     let labeled = le.transform(colors).unwrap();
     assert_eq!(labeled.width(), 1);
 
     // OrdinalEncoder
     let mut oe = featrs::preprocessing::encoder::OrdinalEncoder::new();
-    oe.fit(df.clone(), df.clone()).unwrap();
+    oe.fit(df.clone()).unwrap();
     let ordinal = oe.transform(df).unwrap();
     assert_eq!(ordinal.width(), 2);
 }
@@ -122,7 +121,7 @@ fn test_end_to_end_imputer() {
     let df = DataFrame::new(4, vec![a]).unwrap();
 
     let mut imp = featrs::preprocessing::imputer::SimpleImputer::mean();
-    imp.fit(df.clone(), df.clone()).unwrap();
+    imp.fit(df.clone()).unwrap();
     let filled = imp.transform(df).unwrap();
 
     let vals: Vec<f64> = filled

--- a/tests/time_series_integration.rs
+++ b/tests/time_series_integration.rs
@@ -1,0 +1,75 @@
+use featrs::time_series::cyclical::CyclicalEncoder;
+use featrs::time_series::diff::Difference;
+use featrs::time_series::lag::Lagger;
+use featrs::time_series::rolling::{RollingAggregator, RollingFn};
+use featrs::traits::{Fit, Transform};
+use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+
+fn sales_df() -> DataFrame {
+    let col = Column::from(Series::new("sales".into(), &[1.0_f64, 2.0, 3.0, 4.0, 5.0]));
+    DataFrame::new(5, vec![col]).unwrap()
+}
+
+#[test]
+fn test_lagger_integration() {
+    let mut lagger = Lagger::new(&["sales"], &[1]);
+    let df = sales_df();
+
+    lagger.fit(df.clone()).unwrap();
+    let result = lagger.transform(df).unwrap();
+
+    let names: Vec<String> = result
+        .get_column_names()
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    assert!(
+        names.iter().any(|n| n.contains("lag")),
+        "expected a lag column, got {names:?}"
+    );
+    assert_eq!(result.height(), 5);
+}
+
+#[test]
+fn test_rolling_aggregator_integration() {
+    let mut rolling = RollingAggregator::new(&["sales"], 3, RollingFn::Mean);
+    let df = sales_df();
+
+    rolling.fit(df.clone()).unwrap();
+    let result = rolling.transform(df).unwrap();
+
+    assert_eq!(result.height(), 5);
+}
+
+#[test]
+fn test_difference_integration() {
+    let mut diff = Difference::diff(&["sales"], 1);
+    let df = sales_df();
+
+    diff.fit(df.clone()).unwrap();
+    let result = diff.transform(df).unwrap();
+
+    assert_eq!(result.height(), 5);
+    let names: Vec<String> = result
+        .get_column_names()
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    assert!(
+        names.iter().any(|n| n.contains("diff")),
+        "expected a diff column, got {names:?}"
+    );
+}
+
+#[test]
+fn test_cyclical_encoder_integration() {
+    let mut enc = CyclicalEncoder::new(&["sales"], 7);
+    let df = sales_df();
+
+    enc.fit(df.clone()).unwrap();
+    let result = enc.transform(df).unwrap();
+
+    // CyclicalEncoder adds sin + cos columns for each input column.
+    assert!(result.width() >= 2);
+    assert_eq!(result.height(), 5);
+}


### PR DESCRIPTION
A phased overhaul of featrs resulting in the **0.3.0** breaking release. Six commits, one per phase (1–4 batched). All checks green locally: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (49 unit + 8 integration + 26 doctests), `RUSTDOCFLAGS=-D warnings cargo doc --no-deps`, and the MSRV (1.91) build+test.

## Breaking changes (0.3.0)
- **Split `Fit` into `Fit` / `FitSupervised`.** Unsupervised transformers now take `fit(X)` (no dummy target); only `SelectKBest` takes `fit(X, y)`. **Migration:** drop the second arg to `.fit(...)` everywhere except `SelectKBest`; `use featrs::traits::FitSupervised;` for `SelectKBest`.
- **`MissingIndicator` moved** from `featrs::traits::missing_indicator` to `featrs::preprocessing::missing_indicator` (prelude re-export unchanged).
- **`PolynomialFeatures::new`, `PolynomialFeaturesBuilder::build`, and `Pipeline::new` now return `Result<Self>`** instead of panicking.
- **`FeatureHasher` uses the signed hashing trick** (`±1.0` per bucket via a second hash) — bucket expectations are now zero.

## Correctness & safety
- Replaced `partial_cmp().unwrap()` with `total_cmp()` at the 4 float-sort sites (NaN no longer panics).
- `AutoTypeDetector::transform` no longer re-fits sub-transformers each call (idempotent, O(N)).
- All ~40 production `unwrap`/`expect` replaced with `Result` errors; `clippy::unwrap_used`/`expect_used` now denied in production (tests exempt).

## Hygiene, CI, docs, tests
- MSRV declared as 1.91 (`rust-version`); CI rewritten with caching, Linux/macOS/Windows matrix, rustdoc `-D warnings`, dedicated MSRV job, `cargo audit`, and `cargo publish --dry-run`.
- Crate-level lints (`#![forbid(unsafe_code)]`, `#![warn(missing_docs)]`), `clippy.toml`, fixed 10 `missing_docs` violations.
- New `util` module dedups the column-discovery/replace boilerplate; single canonical re-export list in `prelude`.
- All 26 doctests are now runnable (build real DataFrames, call fit+transform, assert shape).
- New tests: Pipeline multi-step/empty/NotFitted, ColumnTransformer Drop/multiple, SimpleImputer Median/MostFrequent/all-null, time_series integration; runnable `examples/scaling_pipeline.rs`.
- Full migration notes in `CHANGELOG.md`.

See `CHANGELOG.md` for the complete 0.3.0 entry.