### PR TITLE
fix: validate FeatureHasher input dtype at fit time (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-07-07
+
+### Fixed
+
+- `FeatureHasher.fit` now validates that each configured column has `String`
+  dtype, surfacing type errors at fit time instead of pushing them to
+  `transform`. Non-String columns (e.g. numeric) now fail fast per the
+  pipeline contract (#6).
+
 ## [0.3.0] - 2026-07-06
 
 ### Changed (breaking)
@@ -95,7 +104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pipeline primitives: `Pipeline`, `ColumnTransformer` with `Remainder`.
 - Comprehensive API docs, module docs, and contributing guide.
 
-[Unreleased]: https://github.com/DeathSurfing/featrs/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/DeathSurfing/featrs/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/DeathSurfing/featrs/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/DeathSurfing/featrs/releases/tag/v0.3.0
 [0.2.0]: https://github.com/DeathSurfing/featrs/releases/tag/v0.2.0
 [0.1.0]: https://github.com/DeathSurfing/featrs/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "featrs"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.91"
 description = "Feature engineering library for Rust, inspired by scikit-learn"

--- a/src/preprocessing/feature_hasher.rs
+++ b/src/preprocessing/feature_hasher.rs
@@ -82,12 +82,18 @@ impl Fit<DataFrame> for FeatureHasher {
             ));
         }
         for col in &self.columns {
-            if x.column(col.as_str()).is_err() {
-                return Err(Error::InvalidInput(format!(
-                    "FeatureHasher: column '{}' not found.",
-                    col
-                )));
-            }
+            let s = x.column(col.as_str()).map_err(|_| {
+                Error::InvalidInput(format!("FeatureHasher.fit: column '{}' not found.", col))
+            })?;
+            let s = s.as_materialized_series();
+            s.str().map_err(|e| {
+                Error::InvalidInput(format!(
+                    "FeatureHasher.fit: column '{}' has dtype {}; expected String. {}",
+                    col,
+                    s.dtype(),
+                    e
+                ))
+            })?;
         }
         self.fitted = true;
         Ok(())

--- a/src/preprocessing/feature_hasher.rs
+++ b/src/preprocessing/feature_hasher.rs
@@ -198,4 +198,28 @@ mod tests {
             }
         }
     }
+
+    /// `fit` must reject non-String columns early instead of pushing the
+    /// dtype error to `transform` time (regression test for issue #6).
+    #[test]
+    fn test_fit_rejects_non_string_column() {
+        let c = Column::from(Series::new("count".into(), &[1_i32, 2, 3]));
+        let df = DataFrame::new(3, vec![c]).unwrap();
+        let mut fh = FeatureHasher::new(&["count"], 8);
+
+        let err = fh.fit(df.clone()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("expected String"),
+            "error should mention expected String, got: {msg}"
+        );
+
+        // A failed fit must not mark the hasher as fitted; transform then
+        // surfaces `NotFitted` rather than attempting to hash a numeric column.
+        let transform_err = fh.transform(df).unwrap_err().to_string();
+        assert!(
+            transform_err.contains("not fitted"),
+            "transform after a failed fit should report NotFitted, got: {transform_err}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #6.

`FeatureHasher.fit` previously only verified that named columns existed in the DataFrame, without checking their dtype. Type errors (e.g. accidentally passing a numeric column) only surfaced at `transform` time, violating the fail-fast contract and making pipelines harder to debug.

This PR mirrors the existing `transform`-side `String` dtype check into `fit`, so non-String columns are rejected early with an actionable error message. The `transform`-side check is retained for defensive validation.

Scheduled for the **0.3.1** bugfix release (no breaking API changes; only surfaces errors earlier than before).

## Changes
- `src/preprocessing/feature_hasher.rs` — `Fit::fit` now acquires the materialized series and calls `.str()`, producing an `Error::InvalidInput` with the column's actual dtype on mismatch.
- New regression test `test_fit_rejects_non_string_column` asserting fit fails fast on a numeric column with an `expected String` message and that a failed fit leaves the hasher unfitted (transform then reports `NotFitted`).
- `Cargo.toml` bumped to `0.3.1`; `CHANGELOG.md` gained a `[0.3.1]` Fixed section.

## Verification
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test` — all 50 lib + 26 doctests pass.

## Notes
Strictly additive behavior change: code that previously succeeded in `fit` and failed in `transform` will now fail in `fit`. This is exactly what #6 requests.

Closes #6.