### PR TITLE
fix(normalizer): use absolute values in Max norm (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-08
+
+### Fixed
+
+- `Normalizer` Max (L∞) norm now uses absolute values (`max(|x_i|)`) instead
+  of `max(x_i)`, correcting the normalized output for any row containing
+  negative values. The existing `test_max_normalization` test only used
+  positive values, so the bug was previously hidden; a regression test
+  covering negative values has been added (#9).
+
 ## [0.3.1] - 2026-07-07
 
 ### Fixed
@@ -104,7 +114,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pipeline primitives: `Pipeline`, `ColumnTransformer` with `Remainder`.
 - Comprehensive API docs, module docs, and contributing guide.
 
-[Unreleased]: https://github.com/DeathSurfing/featrs/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/DeathSurfing/featrs/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/DeathSurfing/featrs/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/DeathSurfing/featrs/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/DeathSurfing/featrs/releases/tag/v0.3.0
 [0.2.0]: https://github.com/DeathSurfing/featrs/releases/tag/v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "featrs"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 rust-version = "1.91"
 description = "Feature engineering library for Rust, inspired by scikit-learn"

--- a/src/preprocessing/normalizer.rs
+++ b/src/preprocessing/normalizer.rs
@@ -218,4 +218,30 @@ mod tests {
         assert_relative_eq!(col_a.get(0).unwrap(), 0.75, epsilon = 1e-6);
         assert_relative_eq!(col_b.get(0).unwrap(), 1.0, epsilon = 1e-6);
     }
+
+    /// `Max` norm must use absolute values; rows containing negatives must
+    /// normalize by `max(|x_i|)` rather than `max(x_i)` (regression test for
+    /// issue #9). The existing `test_max_normalization` only used positive
+    /// values, so the bug was hidden.
+    #[test]
+    fn test_max_normalization_negative_values() {
+        let a = Column::from(Series::new("a".into(), &[-5.0f64, 1.0]));
+        let b = Column::from(Series::new("b".into(), &[3.0f64, 2.0]));
+        let df = DataFrame::new(2, vec![a, b]).unwrap();
+
+        let mut n = Normalizer::max();
+        n.fit(df.clone()).unwrap();
+        let result = n.transform(df).unwrap();
+
+        let col_a = result.column("a").unwrap().f64().unwrap();
+        let col_b = result.column("b").unwrap().f64().unwrap();
+
+        // Row 0 [-5, 3]: norm = max(|-5|, |3|) = 5.0  -> [-1.0, 0.6]
+        assert_relative_eq!(col_a.get(0).unwrap(), -1.0, epsilon = 1e-6);
+        assert_relative_eq!(col_b.get(0).unwrap(), 0.6, epsilon = 1e-6);
+
+        // Row 1 [1, 2]: norm = max(|1|, |2|) = 2.0  -> [0.5, 1.0]
+        assert_relative_eq!(col_a.get(1).unwrap(), 0.5, epsilon = 1e-6);
+        assert_relative_eq!(col_b.get(1).unwrap(), 1.0, epsilon = 1e-6);
+    }
 }

--- a/src/preprocessing/normalizer.rs
+++ b/src/preprocessing/normalizer.rs
@@ -72,7 +72,7 @@ impl Normalizer {
         match norm {
             Norm::L1 => values.iter().map(|v| v.abs()).sum(),
             Norm::L2 => values.iter().map(|v| v * v).sum::<f64>().sqrt(),
-            Norm::Max => values.iter().cloned().fold(0.0f64, f64::max),
+            Norm::Max => values.iter().map(|v| v.abs()).fold(0.0f64, f64::max),
         }
     }
 }


### PR DESCRIPTION
## Summary

The `Normalizer` Max (L∞ / Chebyshev) norm is defined as `max(|x_i|)`, but the implementation computed `max(x_i)` on raw values, ignoring absolute values. This produced incorrect normalized output for any row containing a negative feature value.

For a row like `[-5.0, 3.0]`:
- **Expected:** norm = `max(|-5|, |3|)` = `5.0` → `[-1.0, 0.6]`
- **Actual (buggy):** norm = `max(-5, 3)` = `3.0` → `[-1.667, 1.0]`

The existing `test_max_normalization` test only used positive values `[3.0, 4.0]`, so the bug was hidden and CI stayed green.

## Changes

- **`src/preprocessing/normalizer.rs:75`** — one-line fix: `values.iter().cloned().fold(0.0f64, f64::max)` → `values.iter().map(|v| v.abs()).fold(0.0f64, f64::max)`. Mirrors the L1/L2 branches, which already operate on `v.abs()` / `v*v`.
- **Regression test** `test_max_normalization_negative_values` — rows `[-5, 3]` and `[1, 2]`; verifies the corrected norms (`5.0`, `2.0`) and normalized output. Confirmed it **fails** on the pre-fix code (`-1.6667` for row 0 col a) and **passes** after the fix.
- **`CHANGELOG.md`** — new `[0.3.2]` patch section documenting the fix.
- **`Cargo.toml`** — version bump `0.3.1` → `0.3.2` (mirrors the PR #10 / v0.3.1 release precedent).

## Verification

- `cargo fmt -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅ — 51 unit + 4 integration + 4 time-series + 26 doctest, 0 failures

## Scope

Single-line functional fix with a non-breaking API; no public API changes (`0.3.2` patch release).

Closes #9.