### PR TITLE
fix: correct NotFitted hint for unsupervised transformers

### DIFF
--- a/src/feature_selection/variance_threshold.rs
+++ b/src/feature_selection/variance_threshold.rs
@@ -128,14 +128,14 @@ impl Transform<DataFrame> for VarianceThreshold {
         if !self.fitted {
             return Err(Error::NotFitted(
                 "VarianceThreshold has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             ));
         }
         let cols = self.selected_columns.as_ref().ok_or_else(|| {
             Error::NotFitted(
                 "VarianceThreshold has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             )
         })?;

--- a/src/preprocessing/binarizer.rs
+++ b/src/preprocessing/binarizer.rs
@@ -73,7 +73,7 @@ impl Transform<DataFrame> for Binarizer {
         if !self.fitted {
             return Err(Error::NotFitted(
                 "Binarizer has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             ));
         }

--- a/src/preprocessing/encoder.rs
+++ b/src/preprocessing/encoder.rs
@@ -140,14 +140,14 @@ impl Transform<DataFrame> for OneHotEncoder {
         if !self.fitted {
             return Err(Error::NotFitted(
                 "OneHotEncoder has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             ));
         }
         let cats = self.categories.as_ref().ok_or_else(|| {
             Error::NotFitted(
                 "OneHotEncoder has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             )
         })?;
@@ -277,14 +277,14 @@ impl Transform<DataFrame> for LabelEncoder {
         if !self.fitted {
             return Err(Error::NotFitted(
                 "LabelEncoder has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             ));
         }
         let mapping = self.mapping.as_ref().ok_or_else(|| {
             Error::NotFitted(
                 "LabelEncoder has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             )
         })?;
@@ -403,7 +403,7 @@ impl Transform<DataFrame> for OrdinalEncoder {
         if !self.fitted {
             return Err(Error::NotFitted(
                 "OrdinalEncoder has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             ));
         }
@@ -412,7 +412,7 @@ impl Transform<DataFrame> for OrdinalEncoder {
         let cats = self.categories.as_ref().ok_or_else(|| {
             Error::NotFitted(
                 "OrdinalEncoder has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             )
         })?;

--- a/src/preprocessing/imputer.rs
+++ b/src/preprocessing/imputer.rs
@@ -183,14 +183,14 @@ impl Transform<DataFrame> for SimpleImputer {
         if !self.fitted {
             return Err(Error::NotFitted(
                 "SimpleImputer has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             ));
         }
         let fill_values = self.fill_values.as_ref().ok_or_else(|| {
             Error::NotFitted(
                 "SimpleImputer has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             )
         })?;

--- a/src/preprocessing/normalizer.rs
+++ b/src/preprocessing/normalizer.rs
@@ -116,7 +116,7 @@ impl Transform<DataFrame> for Normalizer {
         if !self.fitted {
             return Err(Error::NotFitted(
                 "Normalizer has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             ));
         }

--- a/src/preprocessing/polynomial_features.rs
+++ b/src/preprocessing/polynomial_features.rs
@@ -281,14 +281,14 @@ impl Transform<DataFrame> for PolynomialFeatures {
         if !self.fitted {
             return Err(Error::NotFitted(
                 "PolynomialFeatures has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             ));
         }
         let input_columns = self.input_columns.as_ref().ok_or_else(|| {
             Error::NotFitted(
                 "PolynomialFeatures has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             )
         })?;

--- a/src/preprocessing/scaler.rs
+++ b/src/preprocessing/scaler.rs
@@ -157,7 +157,7 @@ impl Transform<DataFrame> for StandardScaler {
         if !self.fitted {
             return Err(Error::NotFitted(
                 "StandardScaler has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             ));
         }
@@ -165,7 +165,7 @@ impl Transform<DataFrame> for StandardScaler {
         let params = self.params.as_ref().ok_or_else(|| {
             Error::NotFitted(
                 "StandardScaler has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             )
         })?;
@@ -301,7 +301,7 @@ impl Transform<DataFrame> for MinMaxScaler {
         if !self.fitted {
             return Err(Error::NotFitted(
                 "MinMaxScaler has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             ));
         }
@@ -311,7 +311,7 @@ impl Transform<DataFrame> for MinMaxScaler {
         for p in self.params.as_ref().ok_or_else(|| {
             Error::NotFitted(
                 "MinMaxScaler has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             )
         })? {
@@ -471,7 +471,7 @@ impl Transform<DataFrame> for RobustScaler {
         if !self.fitted {
             return Err(Error::NotFitted(
                 "RobustScaler has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             ));
         }
@@ -480,7 +480,7 @@ impl Transform<DataFrame> for RobustScaler {
         for p in self.params.as_ref().ok_or_else(|| {
             Error::NotFitted(
                 "RobustScaler has not been fitted. \
-                 Call .fit(dataframe, target) before .transform()."
+                 Call .fit(dataframe) before .transform()."
                     .into(),
             )
         })? {


### PR DESCRIPTION
## Problem

After the `Fit`/`FitSupervised` split (v0.3.0), unsupervised transformers implement `Fit<DataFrame>` with signature `fn fit(&mut self, x: DataFrame)` — no `y` target. However, their `NotFitted` error messages still instructed users to call `.fit(dataframe, target)`, telling them to pass a `target` argument the method does not accept. Following the hint literally produces a compile error.

Closes #11.

## Change

Replaced `Call .fit(dataframe, target) before .transform().` → `Call .fit(dataframe) before .transform().` in **20 `NotFitted` messages across 11 unsupervised transformers** (7 files):

| File | Transformers | Occurrences |
|------|--------------|-------------|
| `src/preprocessing/scaler.rs` | StandardScaler, MinMaxScaler, RobustScaler | 6 |
| `src/preprocessing/encoder.rs` | OneHotEncoder, LabelEncoder, OrdinalEncoder | 6 |
| `src/preprocessing/imputer.rs` | SimpleImputer | 2 |
| `src/preprocessing/polynomial_features.rs` | PolynomialFeatures | 2 |
| `src/feature_selection/variance_threshold.rs` | VarianceThreshold | 2 |
| `src/preprocessing/normalizer.rs` | Normalizer | 1 |
| `src/preprocessing/binarizer.rs` | Binarizer | 1 |

## Not changed

`SelectKBest` (`src/feature_selection/select_kbest.rs:244,251`) — the only `FitSupervised` impl, whose `fn fit(&mut self, x: DataFrame, y: DataFrame)` genuinely requires a target. Its 2 occurrences remain `.fit(dataframe, target)` and are correct.

## Verification

- `cargo build` — clean
- `cargo test` — 86 passed, 0 failed (52 + 4 + 4 + 26, plus all doctests)
- `cargo clippy --all-targets -- -D warnings` — no warnings
- No tests assert on these message strings, so the change is safe.

## Impact

Low severity — no functional change, only error-message text. Purely a documentation fix so the error hint matches the actual API signature.