### PR TITLE
chore: bump version to v0.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "featrs"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.91"
 description = "Feature engineering library for Rust, inspired by scikit-learn"


### PR DESCRIPTION
## Changes

- Bump package version from `0.3.2` → `0.3.3` in `Cargo.toml`
- `Cargo.lock` updated automatically

This version includes:

- `#30` — fix: correct NotFitted hint for unsupervised transformers
- `#29` — fix: SimpleImputer MostFrequent non-deterministic on ties
- `#20` — fix(normalizer): use absolute values in Max norm
- `#10` — fix: validate FeatureHasher input dtype at fit time