### PR TITLE
fix(scaler): error on all-null/all-NaN columns in MinMaxScaler.fit

### DIFF
--- a/src/preprocessing/scaler.rs
+++ b/src/preprocessing/scaler.rs
@@ -267,9 +267,18 @@ impl Fit<DataFrame> for MinMaxScaler {
                     e
                 ))
             })?;
-            let vals: Vec<f64> = ca.iter().flatten().collect();
-            let col_min = vals.iter().cloned().fold(f64::NAN, f64::min);
-            let col_max = vals.iter().cloned().fold(f64::NAN, f64::max);
+            let vals: Vec<f64> = ca.iter().flatten().filter(|v| !v.is_nan()).collect();
+
+            if vals.is_empty() {
+                return Err(Error::Computation(format!(
+                    "MinMaxScaler: column '{}' has no non-null, non-NaN values. \
+                     Cannot scale an all-null or all-NaN column. Impute first or drop the column.",
+                    name
+                )));
+            }
+
+            let col_min = vals.iter().copied().fold(f64::INFINITY, f64::min);
+            let col_max = vals.iter().copied().fold(f64::NEG_INFINITY, f64::max);
 
             if (col_max - col_min).abs() < f64::EPSILON {
                 return Err(Error::Computation(format!(
@@ -539,6 +548,72 @@ mod tests {
         assert_relative_eq!(vals[0], 0.0, epsilon = 1e-6);
         assert_relative_eq!(vals[1], 0.5, epsilon = 1e-6);
         assert_relative_eq!(vals[2], 1.0, epsilon = 1e-6);
+    }
+
+    /// Regression for #12: an all-null column must error at `fit` time instead
+    /// of silently fitting with NaN parameters and propagating NaN on transform.
+    #[test]
+    fn test_min_max_scaler_all_null_column_error() {
+        let x = Column::from(Series::new("x".into(), &[None::<f64>, None, None]));
+        let df = DataFrame::new(3, vec![x]).unwrap();
+        let mut scaler = MinMaxScaler::new();
+        let fit_result = scaler.fit(df.clone());
+        assert!(
+            fit_result.is_err(),
+            "fitting an all-null column must error, not silently fit NaN params"
+        );
+    }
+
+    /// Regression for #12: an all-NaN column (real `f64::NAN` values, not
+    /// Polars nulls) must also error instead of silently propagating NaN.
+    #[test]
+    fn test_min_max_scaler_all_nan_column_error() {
+        let x = Column::from(Series::new("x".into(), &[f64::NAN, f64::NAN, f64::NAN]));
+        let df = DataFrame::new(3, vec![x]).unwrap();
+        let mut scaler = MinMaxScaler::new();
+        let fit_result = scaler.fit(df.clone());
+        assert!(
+            fit_result.is_err(),
+            "fitting an all-NaN column must error, not silently fit NaN params"
+        );
+    }
+
+    /// Nulls mixed with valid values must keep working: the null position is
+    /// preserved through transform, and valid values scale to the range ends.
+    #[test]
+    fn test_min_max_scaler_partial_null_ok() {
+        let x = Column::from(Series::new("x".into(), &[Some(1.0f64), None, Some(5.0)]));
+        let df = DataFrame::new(3, vec![x]).unwrap();
+        let mut scaler = MinMaxScaler::new();
+        scaler.fit(df.clone()).unwrap();
+        let out = scaler.transform(df).unwrap();
+        let ca = out.column("x").unwrap().f64().unwrap();
+        let vals: Vec<Option<f64>> = ca.iter().collect();
+        assert!(
+            vals[1].is_none(),
+            "null input must stay null through transform"
+        );
+        assert_relative_eq!(vals[0].unwrap(), 0.0, epsilon = 1e-6);
+        assert_relative_eq!(vals[2].unwrap(), 1.0, epsilon = 1e-6);
+    }
+
+    /// `f64::NAN` mixed with valid values must keep working: NaN is ignored for
+    /// fit statistics, and the NaN position maps to NaN on transform.
+    #[test]
+    fn test_min_max_scaler_partial_nan_ok() {
+        let x = Column::from(Series::new("x".into(), &[1.0f64, f64::NAN, 5.0]));
+        let df = DataFrame::new(3, vec![x]).unwrap();
+        let mut scaler = MinMaxScaler::new();
+        scaler.fit(df.clone()).unwrap();
+        let out = scaler.transform(df).unwrap();
+        let ca = out.column("x").unwrap().f64().unwrap();
+        let vals: Vec<Option<f64>> = ca.iter().collect();
+        assert_relative_eq!(vals[0].unwrap(), 0.0, epsilon = 1e-6);
+        assert!(
+            vals[1].unwrap().is_nan(),
+            "NaN input must map to NaN through transform"
+        );
+        assert_relative_eq!(vals[2].unwrap(), 1.0, epsilon = 1e-6);
     }
 
     #[test]


### PR DESCRIPTION
## Fixes #12

`MinMaxScaler.fit` silently propagated NaN when a column was entirely null (or entirely `f64::NAN`):

1. `ca.iter().flatten()` yields an empty iterator for an all-null column → `fold(f64::NAN, ...)` returns the `NAN` seed unchanged → `col_min = col_max = NaN`.
2. The constant-column guard `(col_max - col_min).abs() < f64::EPSILON` is `false` for NaN per IEEE 754, so the guard is bypassed.
3. `scale = (r_max - r_min) / (NaN - NaN) = NaN` → the scaler "fits" silently with NaN params and `transform` emits a column of NaNs with no error.

### Root cause
`src/preprocessing/scaler.rs:270-274` — the `fold` was seeded with `f64::NAN`, and no all-null/all-NaN guard existed (unlike `SimpleImputer`, which has `test_imputer_all_null_column_error`).

### Fix
In `MinMaxScaler::fit`:
- Filter `f64::NAN` out of the collected values (in addition to Polars `None`, already filtered by `flatten()`).
- Guard `vals.is_empty()` before the fold, returning `Error::Computation` with a message mirroring `SimpleImputer`'s all-null style.
- Seed the fold with `±INFINITY` instead of `NAN`, so the min/max result no longer depends on `f64::min`'s NaN-propagation semantics — the first fold step is `min(INFINITY, vals[0]) = vals[0]`, unambiguous.

### Behavior
| Column | Before | After |
|---|---|---|
| all `None` | silent NaN params → NaN output | `Err` at `fit` ✓ |
| all `f64::NAN` | silent NaN params → NaN output | `Err` at `fit` ✓ |
| mix valid + `None` | scales ok, null preserved | unchanged ✓ |
| mix valid + `NaN` | depended on `f64::min` NaN semantics | scales ok; NaN ignored in fit, NaN-in→NaN-out in transform (sklearn-faithful) ✓ |
| constant (+ null/NaN) | constant `Err` | unchanged ✓ |

`transform` is unchanged — `replace_f64_column` already preserves `None` and maps `Some(NaN) → NaN`.

### Tests
Regression tests in `scaler.rs::tests`:
- `test_min_max_scaler_all_null_column_error` — `[None, None, None]` → `fit().is_err()`
- `test_min_max_scaler_all_nan_column_error` — `[NAN, NAN, NAN]` → `fit().is_err()`
- `test_min_max_scaler_partial_null_ok` — `[Some(1.0), None, Some(5.0)]` → fit+transform succeed; null stays `None`; endpoints → `0.0`/`1.0`
- `test_min_max_scaler_partial_nan_ok` — `[1.0, NAN, 5.0]` → fit+transform succeed; NaN position → NaN; endpoints → `0.0`/`1.0`

### Verification
- `cargo fmt --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo test` ✓ (57 unit + 4 integration + 4 time-series + 26 doctests)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` ✓

### Scope note
The issue's suggested fix only covered the all-Polars-null case. This PR also catches the all-`f64::NAN` case (real `NaN` bit patterns, not `None`), which has the same silent-NaN-propagation impact and is implied by the issue title ("silently propagates NaN"). `StandardScaler`/`RobustScaler` have a related all-NaN concern but are out of scope for #12.