### PR TITLE
chore: bump version to v0.3.4 and backfill missing 0.3.3 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `MissingIndicator.transform` now always adds indicator columns, even
+  when the transform data has no nulls. Previously the indicator column
+  was conditionally omitted, breaking downstream pipeline schema stability
+  (#32).
+- `MinMaxScaler.fit` now errors on all-null and all-`f64::NAN` columns
+  instead of silently fitting NaN parameters and propagating NaN through
+  `transform`. The constant-column guard was bypassed because
+  `(NaN).abs() < f64::EPSILON` is `false` per IEEE 754 (#33).
+
+## [0.3.3] - 2026-07-08
+
+### Fixed
+
+- Corrected `NotFitted` hint messages across all unsupervised transformers
+  (`StandardScaler`, `MinMaxScaler`, `RobustScaler`, `Normalizer`,
+  `Binarizer`, `OneHotEncoder`, `LabelEncoder`, `OrdinalEncoder`,
+  `SimpleImputer`, `PolynomialFeatures`, `VarianceThreshold`). Each now
+  mentions its own name and tells the user to call `.fit(...)` before
+  `.transform(...)` instead of the generic "call fit" message (#30).
+- `SimpleImputer` `MostFrequent` strategy now deterministically breaks ties
+  (the first mode in column order) instead of silently picking a random
+  value via unstable sort (#29).
+
 ## [0.3.2] - 2026-07-08
 
 ### Fixed
@@ -114,7 +139,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pipeline primitives: `Pipeline`, `ColumnTransformer` with `Remainder`.
 - Comprehensive API docs, module docs, and contributing guide.
 
-[Unreleased]: https://github.com/DeathSurfing/featrs/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/DeathSurfing/featrs/compare/v0.3.4...HEAD
+[0.3.4]: https://github.com/DeathSurfing/featrs/compare/v0.3.3...v0.3.4
+[0.3.3]: https://github.com/DeathSurfing/featrs/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/DeathSurfing/featrs/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/DeathSurfing/featrs/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/DeathSurfing/featrs/releases/tag/v0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "featrs"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 rust-version = "1.91"
 description = "Feature engineering library for Rust, inspired by scikit-learn"


### PR DESCRIPTION
## Summary

Two changes:

### 1. Backfill missing `v0.3.3` CHANGELOG entry

`v0.3.3` was released (commit `0405b56`, PR #31) but its changelog entry was never written. This adds it retroactively, documenting the two fixes:

- **#30** — Correct `NotFitted` hint messages across all unsupervised transformers
- **#29** — `SimpleImputer` `MostFrequent` deterministically breaks ties

### 2. Stage `v0.3.4` (Unreleased)

Adds the `[Unreleased]` section documenting the two bug fixes on `main` since `v0.3.3`:

- **#32** — `MissingIndicator.transform` now always adds indicator columns for schema stability
- **#33** — `MinMaxScaler.fit` errors on all-null/all-NaN columns instead of silently propagating NaN

Bumps `Cargo.toml` version from `0.3.3` → `0.3.4` and updates the link references at the bottom of the changelog.

No source code changes — only `CHANGELOG.md` and `Cargo.toml`.