### PR TITLE
fix: validate k > 0 in SelectKBest::fit()

### DIFF
--- a/src/feature_selection/select_kbest.rs
+++ b/src/feature_selection/select_kbest.rs
@@ -15,6 +15,17 @@ pub trait ScoreFunction: Send + Sync {
     ///
     /// Returns a list of `(column_name, score)` pairs for numeric columns.
     fn score(&self, x: &DataFrame, y: &Column) -> Result<Vec<(String, f64)>>;
+
+    #[test]
+    fn test_select_kbest_k_zero_rejected() {
+        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
+        let features = make_features();
+        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
+        let result = skb.fit(features, y);
+        assert!(result.is_err(), "k=0 should be rejected at fit time");
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
+    }
 }
 
 /// ANOVA F-value scoring function.
@@ -37,11 +48,33 @@ impl FClassif {
     pub fn new() -> Self {
         Self
     }
+
+    #[test]
+    fn test_select_kbest_k_zero_rejected() {
+        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
+        let features = make_features();
+        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
+        let result = skb.fit(features, y);
+        assert!(result.is_err(), "k=0 should be rejected at fit time");
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
+    }
 }
 
 impl Default for FClassif {
     fn default() -> Self {
         Self::new()
+    }
+
+    #[test]
+    fn test_select_kbest_k_zero_rejected() {
+        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
+        let features = make_features();
+        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
+        let result = skb.fit(features, y);
+        assert!(result.is_err(), "k=0 should be rejected at fit time");
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
     }
 }
 
@@ -134,6 +167,17 @@ impl ScoreFunction for FClassif {
 
         Ok(scores)
     }
+
+    #[test]
+    fn test_select_kbest_k_zero_rejected() {
+        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
+        let features = make_features();
+        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
+        let result = skb.fit(features, y);
+        assert!(result.is_err(), "k=0 should be rejected at fit time");
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
+    }
 }
 
 /// Select the top `k` features according to a [`ScoreFunction`].
@@ -170,6 +214,17 @@ pub struct SelectKBest {
     score_fn: Box<dyn ScoreFunction>,
     selected_columns: Option<Vec<String>>,
     scores: Option<Vec<(String, f64)>>,
+
+    #[test]
+    fn test_select_kbest_k_zero_rejected() {
+        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
+        let features = make_features();
+        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
+        let result = skb.fit(features, y);
+        assert!(result.is_err(), "k=0 should be rejected at fit time");
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
+    }
 }
 
 impl SelectKBest {
@@ -193,6 +248,17 @@ impl SelectKBest {
     pub fn scores(&self) -> Option<&[(String, f64)]> {
         self.scores.as_deref()
     }
+
+    #[test]
+    fn test_select_kbest_k_zero_rejected() {
+        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
+        let features = make_features();
+        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
+        let result = skb.fit(features, y);
+        assert!(result.is_err(), "k=0 should be rejected at fit time");
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
+    }
 }
 
 impl FitSupervised<DataFrame, DataFrame> for SelectKBest {
@@ -202,6 +268,12 @@ impl FitSupervised<DataFrame, DataFrame> for SelectKBest {
         if x.width() == 0 {
             return Err(Error::InvalidInput(
                 "SelectKBest.fit received a DataFrame with 0 columns.".into(),
+            ));
+        }
+        if self.k == 0 {
+            return Err(Error::InvalidInput(
+                "SelectKBest: k must be greater than 0, got 0. \n\
+                 Choose k >= 1 to select at least one feature.".into(),
             ));
         }
         if y.width() != 1 {
@@ -231,6 +303,17 @@ impl FitSupervised<DataFrame, DataFrame> for SelectKBest {
         self.selected_columns = Some(selected);
         self.fitted = true;
         Ok(())
+    }
+
+    #[test]
+    fn test_select_kbest_k_zero_rejected() {
+        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
+        let features = make_features();
+        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
+        let result = skb.fit(features, y);
+        assert!(result.is_err(), "k=0 should be rejected at fit time");
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
     }
 }
 
@@ -263,6 +346,17 @@ impl Transform<DataFrame> for SelectKBest {
         let refs: Vec<&str> = cols.iter().map(|s| s.as_str()).collect();
         x.select(refs)
             .map_err(|e| Error::Computation(e.to_string()))
+    }
+
+    #[test]
+    fn test_select_kbest_k_zero_rejected() {
+        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
+        let features = make_features();
+        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
+        let result = skb.fit(features, y);
+        assert!(result.is_err(), "k=0 should be rejected at fit time");
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
     }
 }
 
@@ -310,5 +404,16 @@ mod tests {
 
         let scores = f.score(&features, &y_col).unwrap();
         assert_eq!(scores.len(), 2);
+    }
+
+    #[test]
+    fn test_select_kbest_k_zero_rejected() {
+        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
+        let features = make_features();
+        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
+        let result = skb.fit(features, y);
+        assert!(result.is_err(), "k=0 should be rejected at fit time");
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
     }
 }

--- a/src/feature_selection/select_kbest.rs
+++ b/src/feature_selection/select_kbest.rs
@@ -207,7 +207,8 @@ impl FitSupervised<DataFrame, DataFrame> for SelectKBest {
         if self.k == 0 {
             return Err(Error::InvalidInput(
                 "SelectKBest: k must be greater than 0, got 0. \n\
-                 Choose k >= 1 to select at least one feature.".into(),
+                 Choose k >= 1 to select at least one feature."
+                    .into(),
             ));
         }
         if y.width() != 1 {
@@ -326,6 +327,9 @@ mod tests {
         let result = skb.fit(features, y);
         assert!(result.is_err(), "k=0 should be rejected at fit time");
         let err = result.unwrap_err();
-        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
+        assert!(
+            err.to_string().contains("k must be greater than 0"),
+            "error message should mention k"
+        );
     }
 }

--- a/src/feature_selection/select_kbest.rs
+++ b/src/feature_selection/select_kbest.rs
@@ -15,17 +15,6 @@ pub trait ScoreFunction: Send + Sync {
     ///
     /// Returns a list of `(column_name, score)` pairs for numeric columns.
     fn score(&self, x: &DataFrame, y: &Column) -> Result<Vec<(String, f64)>>;
-
-    #[test]
-    fn test_select_kbest_k_zero_rejected() {
-        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
-        let features = make_features();
-        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
-        let result = skb.fit(features, y);
-        assert!(result.is_err(), "k=0 should be rejected at fit time");
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
-    }
 }
 
 /// ANOVA F-value scoring function.
@@ -48,33 +37,11 @@ impl FClassif {
     pub fn new() -> Self {
         Self
     }
-
-    #[test]
-    fn test_select_kbest_k_zero_rejected() {
-        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
-        let features = make_features();
-        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
-        let result = skb.fit(features, y);
-        assert!(result.is_err(), "k=0 should be rejected at fit time");
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
-    }
 }
 
 impl Default for FClassif {
     fn default() -> Self {
         Self::new()
-    }
-
-    #[test]
-    fn test_select_kbest_k_zero_rejected() {
-        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
-        let features = make_features();
-        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
-        let result = skb.fit(features, y);
-        assert!(result.is_err(), "k=0 should be rejected at fit time");
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
     }
 }
 
@@ -167,17 +134,6 @@ impl ScoreFunction for FClassif {
 
         Ok(scores)
     }
-
-    #[test]
-    fn test_select_kbest_k_zero_rejected() {
-        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
-        let features = make_features();
-        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
-        let result = skb.fit(features, y);
-        assert!(result.is_err(), "k=0 should be rejected at fit time");
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
-    }
 }
 
 /// Select the top `k` features according to a [`ScoreFunction`].
@@ -214,17 +170,6 @@ pub struct SelectKBest {
     score_fn: Box<dyn ScoreFunction>,
     selected_columns: Option<Vec<String>>,
     scores: Option<Vec<(String, f64)>>,
-
-    #[test]
-    fn test_select_kbest_k_zero_rejected() {
-        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
-        let features = make_features();
-        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
-        let result = skb.fit(features, y);
-        assert!(result.is_err(), "k=0 should be rejected at fit time");
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
-    }
 }
 
 impl SelectKBest {
@@ -247,17 +192,6 @@ impl SelectKBest {
     /// Returns `None` if not fitted yet. The list is sorted highest-score first.
     pub fn scores(&self) -> Option<&[(String, f64)]> {
         self.scores.as_deref()
-    }
-
-    #[test]
-    fn test_select_kbest_k_zero_rejected() {
-        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
-        let features = make_features();
-        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
-        let result = skb.fit(features, y);
-        assert!(result.is_err(), "k=0 should be rejected at fit time");
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
     }
 }
 
@@ -304,17 +238,6 @@ impl FitSupervised<DataFrame, DataFrame> for SelectKBest {
         self.fitted = true;
         Ok(())
     }
-
-    #[test]
-    fn test_select_kbest_k_zero_rejected() {
-        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
-        let features = make_features();
-        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
-        let result = skb.fit(features, y);
-        assert!(result.is_err(), "k=0 should be rejected at fit time");
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
-    }
 }
 
 impl Transform<DataFrame> for SelectKBest {
@@ -346,17 +269,6 @@ impl Transform<DataFrame> for SelectKBest {
         let refs: Vec<&str> = cols.iter().map(|s| s.as_str()).collect();
         x.select(refs)
             .map_err(|e| Error::Computation(e.to_string()))
-    }
-
-    #[test]
-    fn test_select_kbest_k_zero_rejected() {
-        let mut skb = SelectKBest::new(0, Box::new(FClassif::new()));
-        let features = make_features();
-        let y = DataFrame::new(6, vec![make_target_col()]).unwrap();
-        let result = skb.fit(features, y);
-        assert!(result.is_err(), "k=0 should be rejected at fit time");
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("k must be greater than 0"), "error message should mention k");
     }
 }
 


### PR DESCRIPTION
## Problem

SelectKBest accepts k=0 without error. PolynomialFeatures rejects degree==0 at construction.

## Fix

Add validation in fit() to reject k==0 with a clear error message. Non-breaking.

- Added k==0 check in fit()
- Added regression test

Fixes DeathSurfing/featrs#38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added input validation to prevent fitting with `k = 0`, returning a clear error stating that `k` must be greater than 0.
  * Improved the reported error message so it’s immediately clear what value is required.
* **Tests**
  * Added a unit test to verify that `fit` fails when `k = 0` and that the error message mentions the `k > 0` requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->