### PR TITLE
docs: backfill missing changelog entries for #44 and #46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of silently fitting NaN parameters and propagating NaN through
   `transform`. The constant-column guard was bypassed because
   `(NaN).abs() < f64::EPSILON` is `false` per IEEE 754 (#33).
+- `SelectKBest.fit` now validates that `k > 0` at fit time, returning a
+  clear `InvalidInput` error for `k == 0` instead of failing silently or
+  with an opaque downstream error (#44).
+- `Binarizer.fit` now rejects empty DataFrames (0 rows) with an
+  `InvalidInput` error, matching the convention of every other transformer
+  in the crate (#46).
 
 ## [0.3.3] - 2026-07-08
 


### PR DESCRIPTION
Backfills two `[Unreleased]` changelog entries that were merged to main but never documented:

- `SelectKBest.fit` k > 0 validation (#44, fixes #38)
- `Binarizer.fit` empty DataFrame rejection (#46, fixes #37)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `SelectKBest` now reports a clear validation error when configured with an invalid value of `k`.
  * `Binarizer` now rejects empty datasets with an appropriate validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->