### PR TITLE
fix(StandardScaler): compute variance using fitted mean regardless of with_mean (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Binarizer.fit` now rejects empty DataFrames (0 rows) with an
   `InvalidInput` error, matching the convention of every other transformer
   in the crate (#46).
+- `StandardScaler.fit` and `RobustScaler.fit` now filter `f64::NAN` values
+  before computing statistics (mean, variance, median, IQR) instead of
+  silently producing NaN parameters that propagate through `transform`.
+  All-null and all-NaN columns now error at fit time (#35).
 
 ## [0.3.3] - 2026-07-08
 

--- a/src/preprocessing/scaler.rs
+++ b/src/preprocessing/scaler.rs
@@ -110,11 +110,11 @@ impl Fit<DataFrame> for StandardScaler {
                 ))
             })?;
 
-            let vals: Vec<f64> = _ca.iter().flatten().filter(|v| !v.is_nan()).collect();
+            let vals: Vec<f64> = _ca.iter().flatten().filter(|v| v.is_finite()).collect();
 
             if vals.is_empty() {
                 return Err(Error::Computation(format!(
-                    "StandardScaler: column '{}' has no non-null, non-NaN values. \
+                    "StandardScaler: column '{}' has no non-null, finite values. \
                      Cannot scale an all-null or all-NaN column. Impute first or drop the column.",
                     name
                 )));
@@ -447,11 +447,11 @@ impl Fit<DataFrame> for RobustScaler {
                     e
                 ))
             })?;
-            let mut vals: Vec<f64> = ca.iter().flatten().filter(|v| !v.is_nan()).collect();
+            let mut vals: Vec<f64> = ca.iter().flatten().filter(|v| v.is_finite()).collect();
 
             if vals.is_empty() {
                 return Err(Error::Computation(format!(
-                    "RobustScaler: column '{}' has no non-null, non-NaN values. \
+                    "RobustScaler: column '{}' has no non-null, finite values. \
                      Cannot scale an all-null or all-NaN column. Impute first or drop the column.",
                     name
                 )));

--- a/src/preprocessing/scaler.rs
+++ b/src/preprocessing/scaler.rs
@@ -447,7 +447,16 @@ impl Fit<DataFrame> for RobustScaler {
                     e
                 ))
             })?;
-            let mut vals: Vec<f64> = ca.iter().flatten().collect();
+            let mut vals: Vec<f64> = ca.iter().flatten().filter(|v| !v.is_nan()).collect();
+
+            if vals.is_empty() {
+                return Err(Error::Computation(format!(
+                    "RobustScaler: column '{}' has no non-null, non-NaN values. \
+                     Cannot scale an all-null or all-NaN column. Impute first or drop the column.",
+                    name
+                )));
+            }
+
             vals.sort_by(|a, b| a.total_cmp(b));
 
             let median = percentile_sorted(&vals, 50.0);
@@ -658,5 +667,115 @@ mod tests {
         // fit must not panic on the NaN-bearing sort.
         scaler.fit(df.clone()).unwrap();
         let _ = scaler.transform(df).unwrap();
+    }
+
+    /// Regression for #35: an all-null column must error at `fit` time instead
+    /// of silently fitting with NaN parameters.
+    #[test]
+    fn test_standard_scaler_all_null_column_error() {
+        let x = Column::from(Series::new("x".into(), &[None::<f64>, None, None]));
+        let df = DataFrame::new(3, vec![x]).unwrap();
+        let mut scaler = StandardScaler::new();
+        let fit_result = scaler.fit(df.clone());
+        assert!(
+            fit_result.is_err(),
+            "fitting an all-null column must error, not silently fit NaN params"
+        );
+    }
+
+    /// Regression for #35: an all-NaN column must error at `fit` time.
+    #[test]
+    fn test_standard_scaler_all_nan_column_error() {
+        let x = Column::from(Series::new("x".into(), &[f64::NAN, f64::NAN, f64::NAN]));
+        let df = DataFrame::new(3, vec![x]).unwrap();
+        let mut scaler = StandardScaler::new();
+        let fit_result = scaler.fit(df.clone());
+        assert!(
+            fit_result.is_err(),
+            "fitting an all-NaN column must error, not silently fit NaN params"
+        );
+    }
+
+    /// Nulls mixed with valid values must keep working: the null position is
+    /// preserved through transform, and valid values scale correctly.
+    #[test]
+    fn test_standard_scaler_partial_null_ok() {
+        let x = Column::from(Series::new("x".into(), &[Some(1.0f64), None, Some(5.0)]));
+        let df = DataFrame::new(3, vec![x]).unwrap();
+        let mut scaler = StandardScaler::new();
+        scaler.fit(df.clone()).unwrap();
+        let out = scaler.transform(df).unwrap();
+        let ca = out.column("x").unwrap().f64().unwrap();
+        let vals: Vec<Option<f64>> = ca.iter().collect();
+        assert!(
+            vals[1].is_none(),
+            "null input must stay null through transform"
+        );
+        assert_relative_eq!(vals[0].unwrap(), -1.0, epsilon = 1e-6);
+        assert_relative_eq!(vals[2].unwrap(), 1.0, epsilon = 1e-6);
+    }
+
+    /// `f64::NAN` mixed with valid values must keep working: NaN is ignored for
+    /// fit statistics, and the NaN position maps to NaN on transform.
+    #[test]
+    fn test_standard_scaler_partial_nan_ok() {
+        let x = Column::from(Series::new("x".into(), &[1.0f64, f64::NAN, 5.0]));
+        let df = DataFrame::new(3, vec![x]).unwrap();
+        let mut scaler = StandardScaler::new();
+        scaler.fit(df.clone()).unwrap();
+        let out = scaler.transform(df).unwrap();
+        let ca = out.column("x").unwrap().f64().unwrap();
+        let vals: Vec<Option<f64>> = ca.iter().collect();
+        assert_relative_eq!(vals[0].unwrap(), -1.0, epsilon = 1e-6);
+        assert!(
+            vals[1].unwrap().is_nan(),
+            "NaN input must map to NaN through transform"
+        );
+        assert_relative_eq!(vals[2].unwrap(), 1.0, epsilon = 1e-6);
+    }
+
+    /// Regression for #35: an all-null column must error at `fit` time.
+    #[test]
+    fn test_robust_scaler_all_null_column_error() {
+        let x = Column::from(Series::new("x".into(), &[None::<f64>, None, None]));
+        let df = DataFrame::new(3, vec![x]).unwrap();
+        let mut scaler = RobustScaler::new();
+        let fit_result = scaler.fit(df.clone());
+        assert!(
+            fit_result.is_err(),
+            "fitting an all-null column must error, not silently fit NaN params"
+        );
+    }
+
+    /// Regression for #35: an all-NaN column must error at `fit` time.
+    #[test]
+    fn test_robust_scaler_all_nan_column_error() {
+        let x = Column::from(Series::new("x".into(), &[f64::NAN, f64::NAN, f64::NAN]));
+        let df = DataFrame::new(3, vec![x]).unwrap();
+        let mut scaler = RobustScaler::new();
+        let fit_result = scaler.fit(df.clone());
+        assert!(
+            fit_result.is_err(),
+            "fitting an all-NaN column must error, not silently fit NaN params"
+        );
+    }
+
+    /// `f64::NAN` mixed with valid values must keep working: NaN is ignored for
+    /// fit statistics, and the NaN position maps to NaN on transform.
+    #[test]
+    fn test_robust_scaler_partial_nan_ok() {
+        let x = Column::from(Series::new("x".into(), &[1.0f64, f64::NAN, 5.0]));
+        let df = DataFrame::new(3, vec![x]).unwrap();
+        let mut scaler = RobustScaler::new();
+        scaler.fit(df.clone()).unwrap();
+        let out = scaler.transform(df).unwrap();
+        let ca = out.column("x").unwrap().f64().unwrap();
+        let vals: Vec<Option<f64>> = ca.iter().collect();
+        assert_relative_eq!(vals[0].unwrap(), -1.0, epsilon = 1e-6);
+        assert!(
+            vals[1].unwrap().is_nan(),
+            "NaN input must map to NaN through transform"
+        );
+        assert_relative_eq!(vals[2].unwrap(), 1.0, epsilon = 1e-6);
     }
 }

--- a/src/preprocessing/scaler.rs
+++ b/src/preprocessing/scaler.rs
@@ -110,19 +110,22 @@ impl Fit<DataFrame> for StandardScaler {
                 ))
             })?;
 
-            let col_mean = if self.with_mean {
-                _ca.mean().unwrap_or(0.0)
-            } else {
-                0.0
-            };
+            let vals: Vec<f64> = _ca.iter().flatten().filter(|v| !v.is_nan()).collect();
+
+            if vals.is_empty() {
+                return Err(Error::Computation(format!(
+                    "StandardScaler: column '{}' has no non-null, non-NaN values. \
+                     Cannot scale an all-null or all-NaN column. Impute first or drop the column.",
+                    name
+                )));
+            }
+
+            let fitted_mean = vals.iter().sum::<f64>() / vals.len() as f64;
+            let col_mean = if self.with_mean { fitted_mean } else { 0.0 };
 
             let col_std = if self.with_std {
-                let var = _ca
-                    .iter()
-                    .flatten()
-                    .map(|v| (v - col_mean).powi(2))
-                    .sum::<f64>()
-                    / _ca.len() as f64;
+                let var =
+                    vals.iter().map(|v| (v - fitted_mean).powi(2)).sum::<f64>() / vals.len() as f64;
                 var.sqrt()
             } else {
                 1.0


### PR DESCRIPTION
## Description

Fixes two issues in `StandardScaler.fit`:

### 1. Variance computed against wrong mean (this PR's specific finding)

When `with_mean = false`, `col_mean` was set to `0.0` and the variance was computed as `(v - 0.0)^2` instead of `(v - actual_mean)^2`. This produced an incorrect standard deviation.

Now the statistical `fitted_mean` is always computed from the data and used for the variance calculation. The `with_mean` flag only controls what `mean` is stored in the params for `transform`.

### 2. NaN silently producing NaN params (consolidated from closed #94)

Both `StandardScaler` and `RobustScaler` now filter NaN values before computing statistics, rather than letting NaN poison the mean/variance/IQR. All-null and all-NaN columns error at `fit` time.

### Tests added (7)
- All-null, all-NaN error, partial-NaN transform preserved — for both scalers

Closes #35.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * StandardScaler and RobustScaler now ignore non-finite (`NaN`) values when computing scaling statistics.
  * `fit` now fails with an error when a feature column contains no finite, valid values (instead of generating invalid parameters).
  * `transform` behavior is corrected to preserve null positions and consistently map `NaN` inputs to `NaN` outputs (including mixed null/`NaN` cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->