### PR TITLE
fix(Lagger): reject duplicate periods at fit time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Lagger.fit` now rejects duplicate periods at fit time, returning a clear
+  `InvalidInput` error instead of silently overwriting lag columns on
+  `transform` (Polars `DataFrame::with_column` replaces same-named columns).
 - `MissingIndicator.transform` now always adds indicator columns, even
   when the transform data has no nulls. Previously the indicator column
   was conditionally omitted, breaking downstream pipeline schema stability

--- a/src/time_series/lag.rs
+++ b/src/time_series/lag.rs
@@ -5,6 +5,7 @@
 
 use crate::traits::{Error, Fit, Result, Transform};
 use polars::prelude::*;
+use std::collections::HashSet;
 
 /// Create lag features by shifting columns.
 ///
@@ -73,6 +74,16 @@ impl Fit<DataFrame> for Lagger {
                 )));
             }
         }
+        let mut seen: HashSet<i64> = HashSet::new();
+        for &p in &self.periods {
+            if !seen.insert(p) {
+                return Err(Error::InvalidInput(format!(
+                    "Lagger: duplicate period {} in periods {:?}. \
+                     Each lag period must be unique.",
+                    p, self.periods
+                )));
+            }
+        }
         self.fitted = true;
         Ok(())
     }
@@ -122,5 +133,23 @@ mod tests {
 
         assert_eq!(result.width(), 3); // x, x_lag_1, x_lag_2
         assert_eq!(result.height(), 5);
+    }
+
+    #[test]
+    fn test_lagger_duplicate_periods_rejected() {
+        let vals = Column::from(Series::new("x".into(), &[1.0f64, 2.0, 3.0, 4.0, 5.0]));
+        let df = DataFrame::new(5, vec![vals]).unwrap();
+        let mut lagger = Lagger::new(&["x"], &[1, 1]);
+
+        let result = lagger.fit(df);
+        assert!(
+            result.is_err(),
+            "duplicate periods should be rejected at fit"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate period"),
+            "error message should mention 'duplicate period', got: {err}"
+        );
     }
 }

--- a/src/time_series/lag.rs
+++ b/src/time_series/lag.rs
@@ -147,9 +147,21 @@ mod tests {
             "duplicate periods should be rejected at fit"
         );
         let err = result.unwrap_err();
+        let payload = match err {
+            Error::InvalidInput(msg) => msg,
+            other => panic!("expected Error::InvalidInput, got {other:?}"),
+        };
         assert!(
-            err.to_string().contains("duplicate period"),
-            "error message should mention 'duplicate period', got: {err}"
+            payload.contains("duplicate period"),
+            "error message should mention 'duplicate period', got: {payload}"
+        );
+        assert!(
+            payload.contains(" 1 ") || payload.contains(" 1,"),
+            "error message should contain the duplicate value '1', got: {payload}"
+        );
+        assert!(
+            payload.contains("[1, 1]"),
+            "error message should contain the full periods list '[1, 1]', got: {payload}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #40.

`Lagger::new(&["x"], &[1, 1])` accepted duplicate periods without error. On `transform`, both periods emit a `with_column` call named `x_lag_1`; Polars `DataFrame::with_column` **overwrites** an existing same-named column rather than erroring, so the second `x_lag_1` silently replaced the first — silent data loss with no signal.

## Changes

- **`src/time_series/lag.rs`**: `Lagger::fit` now detects duplicate periods at fit time and returns `Error::InvalidInput` naming the offending period and the full `periods` list. Mirrors the crate's "validate at fit" convention (cf. `SelectKBest::fit` rejecting `k == 0` in #44, `Binarizer::fit` rejecting empty rows in #46).
  - Added `use std::collections::HashSet;`.
  - The check runs in `fit` (not `new`, which returns `Self`) to avoid a breaking API change.
- Added regression test `test_lagger_duplicate_periods_rejected` asserting both `is_err()` and that the message contains `"duplicate period"`.
- **`CHANGELOG.md`**: added an entry under `## [Unreleased] ### Fixed`.

## Repro (from issue)

```rust
let vals = Column::from(Series::new("x".into(), &[1.0_f64, 2.0, 3.0, 4.0, 5.0]));
let df = DataFrame::new(5, vec![vals]).unwrap();
let mut lagger = Lagger::new(&["x"], &[1, 1]);
lagger.fit(df.clone()).unwrap(); // now errors instead of succeeding
```

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅ — 67 unit + 4 + 4 integration + 26 doc-tests pass, including the new test.

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate lag periods are now rejected during model fitting with a clear validation error (instead of being overwritten later).
  * Prevents duplicate lag features from being silently overwritten during transformation.
* **Tests**
  * Added coverage to ensure duplicate periods fail `fit` and that the error message includes the duplicate value.
* **Documentation**
  * Updated the unreleased changelog with the fix details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->