### PR TITLE
feat: LazyFrame support (FitLazy/TransformLazy traits) - closes #79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **LazyFrame support** (`FitLazy` / `TransformLazy` traits, closes #79).
+  Every transformer now accepts a Polars `LazyFrame` in addition to `DataFrame`.
+  The default implementation collects eagerly and re-lazifies, so all existing
+  transformers work out of the box. Six transformers override `transform_lazy`
+  with zero-copy Polars expressions that stay inside the query plan:
+  `StandardScaler` (`(col - mean) / std`), `MinMaxScaler`, `RobustScaler`,
+  `Binarizer` (`when/then/otherwise` with correct `null`/`NaN` propagation),
+  `VarianceThreshold`, and `SelectKBest` (both use `select(cols)` for
+  projection pushdown). `Pipeline` and `ColumnTransformer` chain lazy
+  transforms sequentially / horizontally so an entire pipeline can be
+  expressed as a single optimized Polars query plan.
+- `FitLazy` and `TransformLazy` exported from `featrs::prelude`.
+- `DataFrameTransformer` trait alias now requires `FitLazy + TransformLazy`
+  in addition to `Fit + Transform`.
+
 ### Fixed
 
 - `Lagger.fit` now rejects duplicate periods at fit time, returning a clear

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["feature-engineering", "machine-learning", "preprocessing", "scikit-
 categories = ["science", "data-structures"]
 
 [dependencies]
-polars = "0.54"
+polars = { version = "0.54", features = ["lazy", "strings", "temporal"] }
 thiserror = "2"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 Feature engineering library for Rust, inspired by scikit-learn.
 
 Built on [Polars](https://pola.rs) — all transformations operate natively on `DataFrame` and preserve column names.
+Every transformer also supports Polars `LazyFrame` through the `FitLazy` and `TransformLazy` traits,
+enabling query-plan optimization, predicate pushdown, and out-of-core streaming.
 
 ## Installation
 
@@ -52,6 +54,7 @@ let scaled = scaler.transform(data)?;
 | **Selection** | `VarianceThreshold` | Remove low-variance features |
 | | `SelectKBest` | Select top-k features by statistical test (ANOVA F) |
 | **Auto** | `AutoTypeDetector` | Auto-detect column types and apply default transforms |
+| **Lazy API** | `FitLazy` / `TransformLazy` | Execute any transformer on a Polars `LazyFrame`; six transformers use zero-copy expressions |
 
 ## Examples
 
@@ -65,7 +68,7 @@ scaler.fit(df.clone())?;
 let scaled = scaler.transform(df)?;
 ```
 
-### Pipeline
+### Pipeline (eager)
 
 ```rust
 use featrs::prelude::*;
@@ -76,6 +79,19 @@ let mut pipeline = Pipeline::new(vec![
 ])?;
 pipeline.fit(df.clone())?;
 let result = pipeline.transform(df)?;
+```
+
+### Pipeline (lazy — single optimized Polars query plan)
+
+```rust
+use featrs::prelude::*;
+
+let mut pipeline = Pipeline::new(vec![
+    ("scale".into(), Box::new(StandardScaler::new())),
+    ("binarize".into(), Box::new(Binarizer::new(0.0))),
+])?;
+pipeline.fit_lazy(df.clone().lazy())?;
+let result = pipeline.transform_lazy(df.lazy())?.collect()?;
 ```
 
 ### ColumnTransformer

--- a/src/feature_selection/select_kbest.rs
+++ b/src/feature_selection/select_kbest.rs
@@ -3,7 +3,7 @@
 //! Provides [`SelectKBest`] and the [`FClassif`] scoring function
 //! (ANOVA F-value between each feature and the target).
 
-use crate::traits::{Error, FitSupervised, Result, Transform};
+use crate::traits::{Error, FitSupervised, Result, Transform, TransformLazy};
 use polars::prelude::*;
 
 /// Scoring function for [`SelectKBest`].
@@ -270,6 +270,34 @@ impl Transform<DataFrame> for SelectKBest {
         let refs: Vec<&str> = cols.iter().map(|s| s.as_str()).collect();
         x.select(refs)
             .map_err(|e| Error::Computation(e.to_string()))
+    }
+}
+
+impl TransformLazy for SelectKBest {
+    fn transform_lazy(&self, x: LazyFrame) -> Result<LazyFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted(
+                "SelectKBest has not been fitted. \
+                 Call .fit(dataframe, target) before .transform()."
+                    .into(),
+            ));
+        }
+        let cols = self.selected_columns.as_ref().ok_or_else(|| {
+            Error::NotFitted(
+                "SelectKBest has not been fitted. \
+                 Call .fit(dataframe, target) before .transform()."
+                    .into(),
+            )
+        })?;
+        if cols.is_empty() {
+            return Err(Error::Computation(
+                "SelectKBest: no columns were selected. \
+                 This may mean the scoring function returned no valid scores."
+                    .into(),
+            ));
+        }
+        let exprs: Vec<Expr> = cols.iter().map(|name| col(name.as_str())).collect();
+        Ok(x.select(exprs))
     }
 }
 

--- a/src/feature_selection/variance_threshold.rs
+++ b/src/feature_selection/variance_threshold.rs
@@ -186,7 +186,10 @@ mod tests {
         // Col 'a': [1.0, null, NaN, 5.0]. Non-null/non-nan: [1.0, 5.0].
         // Mean = 3.0. Variance = ((1-3)^2 + (5-3)^2)/2 = 4.0.
         // Col 'b': [2.0, 2.0, 2.0, 2.0]. Variance = 0.0.
-        let a = Column::from(Series::new("a".into(), &[Some(1.0f64), None, Some(f64::NAN), Some(5.0)]));
+        let a = Column::from(Series::new(
+            "a".into(),
+            &[Some(1.0f64), None, Some(f64::NAN), Some(5.0)],
+        ));
         let b = Column::from(Series::new("b".into(), &[2.0f64, 2.0, 2.0, 2.0]));
         let df = DataFrame::new(4, vec![a, b]).unwrap();
 

--- a/src/feature_selection/variance_threshold.rs
+++ b/src/feature_selection/variance_threshold.rs
@@ -2,8 +2,12 @@
 //!
 //! [`VarianceThreshold`] removes features whose variance does not meet
 //! a threshold, i.e. features that are constant or nearly constant.
+//!
+//! Implements [`TransformLazy`] with a
+//! `select(selected_cols)` Polars expression, enabling predicate and
+//! projection pushdown in lazy pipelines.
 
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, Fit, FitLazy, Result, Transform, TransformLazy};
 use polars::prelude::*;
 
 /// Remove features with variance below a threshold.
@@ -13,6 +17,10 @@ use polars::prelude::*;
 ///
 /// Only `Float64` columns are considered; columns of other dtypes are silently
 /// dropped from the output.
+///
+/// Implements [`TransformLazy`] with a
+/// `select(selected_cols)` expression, allowing Polars to push column
+/// projections through the rest of the query plan.
 ///
 /// # Example
 ///
@@ -145,6 +153,29 @@ impl Transform<DataFrame> for VarianceThreshold {
         let refs: Vec<&str> = cols.iter().map(|s| s.as_str()).collect();
         x.select(refs)
             .map_err(|e| Error::Computation(e.to_string()))
+    }
+}
+
+impl FitLazy for VarianceThreshold {}
+
+impl TransformLazy for VarianceThreshold {
+    fn transform_lazy(&self, x: LazyFrame) -> Result<LazyFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted(
+                "VarianceThreshold has not been fitted. \
+                 Call .fit(dataframe) before .transform()."
+                    .into(),
+            ));
+        }
+        let cols = self.selected_columns.as_ref().ok_or_else(|| {
+            Error::NotFitted(
+                "VarianceThreshold has not been fitted. \
+                 Call .fit(dataframe) before .transform()."
+                    .into(),
+            )
+        })?;
+        let exprs: Vec<Expr> = cols.iter().map(|name| col(name.as_str())).collect();
+        Ok(x.select(exprs))
     }
 }
 

--- a/src/feature_selection/variance_threshold.rs
+++ b/src/feature_selection/variance_threshold.rs
@@ -96,9 +96,12 @@ impl Fit<DataFrame> for VarianceThreshold {
                     e
                 ))
             })?;
-            let mean = ca.mean().unwrap_or(0.0);
-            let var =
-                ca.iter().flatten().map(|v| (v - mean).powi(2)).sum::<f64>() / ca.len() as f64;
+            let vals: Vec<f64> = ca.iter().flatten().filter(|v| !v.is_nan()).collect();
+            if vals.is_empty() {
+                continue;
+            }
+            let mean = vals.iter().sum::<f64>() / vals.len() as f64;
+            let var = vals.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / vals.len() as f64;
 
             if var >= self.threshold {
                 selected.push(name);
@@ -176,5 +179,22 @@ mod tests {
         let result = vt.transform(df).unwrap();
 
         assert_eq!(result.width(), 2);
+    }
+
+    #[test]
+    fn test_variance_threshold_with_null_and_nan() {
+        // Col 'a': [1.0, null, NaN, 5.0]. Non-null/non-nan: [1.0, 5.0].
+        // Mean = 3.0. Variance = ((1-3)^2 + (5-3)^2)/2 = 4.0.
+        // Col 'b': [2.0, 2.0, 2.0, 2.0]. Variance = 0.0.
+        let a = Column::from(Series::new("a".into(), &[Some(1.0f64), None, Some(f64::NAN), Some(5.0)]));
+        let b = Column::from(Series::new("b".into(), &[2.0f64, 2.0, 2.0, 2.0]));
+        let df = DataFrame::new(4, vec![a, b]).unwrap();
+
+        let mut vt = VarianceThreshold::new(1.0);
+        vt.fit(df.clone()).unwrap();
+        let result = vt.transform(df).unwrap();
+
+        assert_eq!(result.width(), 1);
+        assert_eq!(result.get_column_names()[0].as_str(), "a");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,13 @@
 //! `featrs` — feature engineering for Rust, inspired by scikit-learn.
 //!
 //! Built on [Polars](https://pola.rs), all transformations operate on
-//! `DataFrame` and preserve column names throughout.
+//! `DataFrame` and preserve column names throughout. Every transformer also
+//! supports Polars [`LazyFrame`](polars::prelude::LazyFrame) through the
+//! [`FitLazy`] and
+//! [`TransformLazy`] traits, enabling
+//! query-plan optimization, predicate pushdown, and streaming for large datasets.
 //!
-//! # Quick start
+//! # Quick start — eager
 //!
 //! ```rust
 //! use featrs::prelude::*;
@@ -19,15 +23,31 @@
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
+//! # Quick start — lazy
+//!
+//! ```rust
+//! use featrs::prelude::*;
+//! use polars::prelude::{Column, DataFrame, IntoLazy, NamedFrom, Series};
+//!
+//! let col = Column::from(Series::new("x".into(), &[1.0_f64, 2.0, 3.0]));
+//! let df = DataFrame::new(3, vec![col])?;
+//!
+//! let mut scaler = StandardScaler::new();
+//! scaler.fit_lazy(df.clone().lazy())?;
+//! let result = scaler.transform_lazy(df.lazy())?.collect()?;
+//! assert_eq!(result.height(), 3);
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
 //! # Modules
 //!
 //! | Module | Description |
 //! |---|---|
 //! | [`prelude`] | Convenient glob-import of the most common types |
 //! | [`preprocessing`] | Scaling, encoding, normalization, imputation, binarization, polynomial features, feature hashing, auto-type detection |
-//! | [`pipeline`] | `Pipeline` (sequential) and `ColumnTransformer` (per-column transforms) |
+//! | [`pipeline`] | `Pipeline` (sequential) and `ColumnTransformer` (per-column transforms) — both support lazy execution |
 //! | [`feature_selection`] | `VarianceThreshold`, `SelectKBest` with ANOVA F-value scoring |
-//! | [`traits`] | Core `Fit`, `Transform`, `FitTransform` traits and error types |
+//! | [`traits`] | Core `Fit`, `Transform`, `FitTransform`, `FitLazy`, `TransformLazy` traits and error types |
 //! | [`time_series`] | Lag features, rolling windows, difference, cyclical encoding |
 
 #![forbid(unsafe_code)]
@@ -79,7 +99,9 @@ pub mod prelude {
     pub use crate::time_series::diff::Difference;
     pub use crate::time_series::lag::Lagger;
     pub use crate::time_series::rolling::RollingAggregator;
-    pub use crate::traits::{Error, Fit, FitSupervised, FitTransform, Result, Transform};
+    pub use crate::traits::{
+        Error, Fit, FitLazy, FitSupervised, FitTransform, Result, Transform, TransformLazy,
+    };
 }
 
 // --- Shallow re-exports at crate root ---

--- a/src/pipeline/column_transformer.rs
+++ b/src/pipeline/column_transformer.rs
@@ -5,7 +5,7 @@
 //! [`DataFrame`].
 
 use crate::pipeline::DataFrameTransformer;
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, Fit, FitLazy, Result, Transform, TransformLazy};
 use polars::prelude::*;
 use std::collections::HashSet;
 
@@ -181,6 +181,83 @@ impl Transform<DataFrame> for ColumnTransformer {
     }
 }
 
+impl FitLazy for ColumnTransformer {
+    fn fit_lazy(&mut self, mut x: LazyFrame) -> Result<()> {
+        let schema = x
+            .collect_schema()
+            .map_err(|e| Error::Computation(e.to_string()))?;
+        if schema.is_empty() {
+            return Err(Error::InvalidInput(
+                "ColumnTransformer.fit received a LazyFrame with 0 columns.".into(),
+            ));
+        }
+        for (t_name, transformer, columns) in &mut self.transformers {
+            let exprs: Vec<Expr> = columns.iter().map(|c| col(c.as_str())).collect();
+            let subset = x.clone().select(exprs);
+            transformer.fit_lazy(subset).map_err(|e| {
+                Error::Computation(format!(
+                    "ColumnTransformer: transformer '{}' failed during lazy fit: {}",
+                    t_name, e
+                ))
+            })?;
+        }
+        Ok(())
+    }
+}
+
+impl TransformLazy for ColumnTransformer {
+    fn transform_lazy(&self, mut x: LazyFrame) -> Result<LazyFrame> {
+        let mut parts: Vec<LazyFrame> = Vec::new();
+
+        for (t_name, transformer, columns) in &self.transformers {
+            let exprs: Vec<Expr> = columns.iter().map(|c| col(c.as_str())).collect();
+            let subset = x.clone().select(exprs);
+            let transformed = transformer.transform_lazy(subset).map_err(|e| {
+                Error::Computation(format!(
+                    "ColumnTransformer: transformer '{}' failed during lazy transform: {}",
+                    t_name, e
+                ))
+            })?;
+            parts.push(transformed);
+        }
+
+        let specified = self.all_specified_columns();
+        match self.remainder {
+            Remainder::Passthrough => {
+                let schema = x
+                    .collect_schema()
+                    .map_err(|e| Error::Computation(e.to_string()))?;
+                let remaining_cols: Vec<Expr> = schema
+                    .iter()
+                    .filter(|(name, _)| !specified.contains(name.as_str()))
+                    .map(|(name, _)| col(name.as_str()))
+                    .collect();
+                if !remaining_cols.is_empty() {
+                    let remaining = x.clone().select(remaining_cols);
+                    parts.push(remaining);
+                }
+            }
+            Remainder::Drop => {}
+        }
+
+        if parts.is_empty() {
+            return Err(Error::InvalidInput(
+                "ColumnTransformer produced no output columns. \
+                 Check that at least one transformer has matching input columns \
+                 or use Remainder::Passthrough to keep unspecified columns."
+                    .into(),
+            ));
+        }
+
+        polars::prelude::concat_lf_horizontal(parts, HConcatOptions::default()).map_err(|e| {
+            Error::Computation(format!(
+                "ColumnTransformer: failed to horizontally concatenate: {}",
+                e
+            ))
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -252,5 +329,29 @@ mod tests {
         );
         let df = make_test_df();
         assert!(ct.transform(df).is_err());
+    }
+
+    #[test]
+    fn test_column_transformer_lazy() {
+        let scaler_a = StandardScaler::new();
+        let scaler_b = StandardScaler::new();
+        let mut ct = ColumnTransformer::new(
+            vec![
+                ("scale_a".into(), Box::new(scaler_a), vec!["a".into()]),
+                ("scale_b".into(), Box::new(scaler_b), vec!["b".into()]),
+            ],
+            Remainder::Passthrough,
+        );
+        let df = make_test_df();
+
+        ct.fit_lazy(df.clone().lazy()).unwrap();
+        let eager_out = ct.transform(df.clone()).unwrap();
+        let lazy_out = ct
+            .transform_lazy(df.clone().lazy())
+            .unwrap()
+            .collect()
+            .unwrap();
+
+        assert_eq!(eager_out, lazy_out);
     }
 }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -4,25 +4,34 @@
 //! - [`Pipeline`] chains multiple transformers sequentially.
 //! - [`ColumnTransformer`] applies different transformers to different column subsets.
 //! - [`DataFrameTransformer`] is a trait alias for type erasure.
+//!
+//! Both [`Pipeline`] and [`ColumnTransformer`] implement [`FitLazy`] and
+//! [`TransformLazy`], so an entire pipeline can be expressed as a Polars
+//! query plan and executed in a single optimized pass. Steps that do not
+//! provide a custom lazy implementation degrade gracefully to eager execution.
 
 pub mod column_transformer;
 
 pub use column_transformer::ColumnTransformer;
 
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, Fit, FitLazy, Result, Transform, TransformLazy};
 use polars::prelude::*;
 
 /// Trait alias for [`Box<dyn ...>`](Box) type erasure in [`Pipeline`] and [`ColumnTransformer`].
 ///
 /// Automatically implemented for any type that satisfies both
 /// [`Fit<DataFrame, Output = ()>`](crate::traits::Fit) and
-/// [`Transform<DataFrame, Output = DataFrame>`](crate::traits::Transform).
+/// [`Transform<DataFrame, Output = DataFrame>`](crate::traits::Transform),
+/// plus [`FitLazy`] and [`TransformLazy`].
 pub trait DataFrameTransformer:
-    Fit<DataFrame, Output = ()> + Transform<DataFrame, Output = DataFrame>
+    Fit<DataFrame, Output = ()> + Transform<DataFrame, Output = DataFrame> + FitLazy + TransformLazy
 {
 }
 impl<T> DataFrameTransformer for T where
-    T: Fit<DataFrame, Output = ()> + Transform<DataFrame, Output = DataFrame>
+    T: Fit<DataFrame, Output = ()>
+        + Transform<DataFrame, Output = DataFrame>
+        + FitLazy
+        + TransformLazy
 {
 }
 
@@ -32,7 +41,7 @@ impl<T> DataFrameTransformer for T where
 /// sequentially (passing each step's output into the next). Calling
 /// `transform(X)` passes data through every step.
 ///
-/// # Example
+/// # Eager example
 ///
 /// ```rust
 /// use featrs::pipeline::Pipeline;
@@ -48,6 +57,26 @@ impl<T> DataFrameTransformer for T where
 /// ])?;
 /// pipeline.fit(df.clone())?;
 /// let result = pipeline.transform(df)?;
+/// assert_eq!(result.height(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// # Lazy example
+///
+/// ```rust
+/// use featrs::pipeline::Pipeline;
+/// use featrs::preprocessing::scaler::StandardScaler;
+/// use featrs::traits::{FitLazy, TransformLazy};
+/// use polars::prelude::{Column, DataFrame, IntoLazy, NamedFrom, Series};
+///
+/// let col = Column::from(Series::new("x".into(), &[1.0_f64, 2.0, 3.0]));
+/// let df = DataFrame::new(3, vec![col])?;
+///
+/// let mut pipeline = Pipeline::new(vec![
+///     ("scale".into(), Box::new(StandardScaler::new())),
+/// ])?;
+/// pipeline.fit_lazy(df.clone().lazy())?;
+/// let result = pipeline.transform_lazy(df.lazy())?.collect()?;
 /// assert_eq!(result.height(), 3);
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
@@ -128,6 +157,51 @@ impl Transform<DataFrame> for Pipeline {
     }
 }
 
+impl FitLazy for Pipeline {
+    fn fit_lazy(&mut self, x: LazyFrame) -> Result<()> {
+        if self.steps.is_empty() {
+            return Err(Error::InvalidInput(
+                "Pipeline.fit received an empty steps list.".into(),
+            ));
+        }
+        let mut x_curr = x;
+        let n = self.steps.len();
+        for (i, (name, transformer)) in self.steps.iter_mut().enumerate() {
+            let is_last = i == n - 1;
+            transformer.fit_lazy(x_curr.clone()).map_err(|e| {
+                Error::Computation(format!(
+                    "Pipeline: step {} ('{}') failed during lazy fit: {}",
+                    i, name, e
+                ))
+            })?;
+            if !is_last {
+                x_curr = transformer.transform_lazy(x_curr).map_err(|e| {
+                    Error::Computation(format!(
+                        "Pipeline: step {} ('{}') failed during intermediate lazy transform: {}",
+                        i, name, e
+                    ))
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl TransformLazy for Pipeline {
+    fn transform_lazy(&self, x: LazyFrame) -> Result<LazyFrame> {
+        let mut x_curr = x;
+        for (i, (name, transformer)) in self.steps.iter().enumerate() {
+            x_curr = transformer.transform_lazy(x_curr).map_err(|e| {
+                Error::Computation(format!(
+                    "Pipeline: step {} ('{}') failed during lazy transform: {}",
+                    i, name, e
+                ))
+            })?;
+        }
+        Ok(x_curr)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -183,5 +257,27 @@ mod tests {
         let pipeline = Pipeline::new(vec![("scaler".into(), Box::new(scaler))]).unwrap();
         let df = make_test_df();
         assert!(pipeline.transform(df).is_err());
+    }
+
+    #[test]
+    fn test_pipeline_lazy() {
+        let scaler = StandardScaler::new();
+        let binarizer = Binarizer::new(0.0);
+        let mut pipeline = Pipeline::new(vec![
+            ("scaler".into(), Box::new(scaler)),
+            ("binarizer".into(), Box::new(binarizer)),
+        ])
+        .unwrap();
+        let df = make_test_df();
+
+        pipeline.fit_lazy(df.clone().lazy()).unwrap();
+        let eager_out = pipeline.transform(df.clone()).unwrap();
+        let lazy_out = pipeline
+            .transform_lazy(df.clone().lazy())
+            .unwrap()
+            .collect()
+            .unwrap();
+
+        assert_eq!(eager_out, lazy_out);
     }
 }

--- a/src/preprocessing/auto_type.rs
+++ b/src/preprocessing/auto_type.rs
@@ -7,7 +7,7 @@
 use crate::pipeline::DataFrameTransformer;
 use crate::preprocessing::encoder::OneHotEncoder;
 use crate::preprocessing::feature_hasher::FeatureHasher;
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, Fit, FitLazy, Result, Transform, TransformLazy};
 use polars::prelude::*;
 
 /// How to treat each detected column type.
@@ -252,6 +252,9 @@ impl Transform<DataFrame> for AutoTypeDetector {
         Ok(result)
     }
 }
+
+impl FitLazy for AutoTypeDetector {}
+impl TransformLazy for AutoTypeDetector {}
 
 #[cfg(test)]
 mod tests {

--- a/src/preprocessing/binarizer.rs
+++ b/src/preprocessing/binarizer.rs
@@ -1,15 +1,25 @@
 //! Feature binarization.
 //!
 //! [`Binarizer`] thresholds numeric features: values above the threshold
-//! become `1.0`, others become `0.0`.
+//! become `1.0`, others become `0.0`. `null` values are preserved as-is;
+//! `NaN` values are also propagated unchanged.
+//!
+//! Implements [`TransformLazy`] with a
+//! `when/then/otherwise` Polars expression, so it integrates into lazy
+//! pipelines without materializing intermediate `DataFrame`s.
 
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, Fit, FitLazy, Result, Transform, TransformLazy};
 use crate::util::replace_f64_column;
 use polars::prelude::*;
 
 /// Binarize data according to a threshold.
 ///
-/// Values `> threshold` become `1.0`; all others become `0.0`.
+/// Values `> threshold` become `1.0`; values `<= threshold` become `0.0`.
+/// `null` values are preserved as `null`; `NaN` values are propagated as `NaN`.
+///
+/// Implements [`TransformLazy`] with a
+/// `when/then/otherwise` Polars expression that handles `null` and `NaN`
+/// propagation without materializing the `LazyFrame`.
 ///
 /// # Example
 ///
@@ -101,11 +111,57 @@ impl Transform<DataFrame> for Binarizer {
 
         for name in &col_names {
             replace_f64_column(&mut out, name.as_str(), "Binarizer", |v| {
-                if v > threshold { 1.0 } else { 0.0 }
+                if v.is_nan() {
+                    v
+                } else if v > threshold {
+                    1.0
+                } else {
+                    0.0
+                }
             })?;
         }
 
         Ok(out)
+    }
+}
+
+impl FitLazy for Binarizer {}
+
+impl TransformLazy for Binarizer {
+    fn transform_lazy(&self, mut x: LazyFrame) -> Result<LazyFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted(
+                "Binarizer has not been fitted. \
+                 Call .fit(dataframe) before .transform()."
+                    .into(),
+            ));
+        }
+
+        let schema = x
+            .collect_schema()
+            .map_err(|e| Error::Computation(e.to_string()))?;
+        let mut exprs = Vec::new();
+        let threshold = self.threshold;
+
+        for (name, dtype) in schema.iter() {
+            if dtype == &DataType::Float64 {
+                let name_str = name.as_str();
+                exprs.push(
+                    when(col(name_str).is_null())
+                        .then(lit(Null {}))
+                        .otherwise(
+                            when(col(name_str).is_nan()).then(lit(f64::NAN)).otherwise(
+                                when(col(name_str).gt(lit(threshold)))
+                                    .then(lit(1.0))
+                                    .otherwise(lit(0.0)),
+                            ),
+                        )
+                        .alias(name_str),
+                );
+            }
+        }
+
+        Ok(x.with_columns(exprs))
     }
 }
 
@@ -174,5 +230,53 @@ mod tests {
             err.to_string().contains("empty DataFrame"),
             "error message should mention the empty DataFrame"
         );
+    }
+
+    #[test]
+    fn test_lazy_binarizer() {
+        let mut b = Binarizer::new(0.5);
+        let a = Column::from(Series::new("x".into(), &[-1.0f64, 0.5, 2.0, f64::NAN]));
+        let df = DataFrame::new(4, vec![a]).unwrap();
+
+        b.fit(df.clone()).unwrap();
+        let eager_out = b.transform(df.clone()).unwrap();
+        let lazy_out = b
+            .transform_lazy(df.clone().lazy())
+            .unwrap()
+            .collect()
+            .unwrap();
+
+        let eager_vals: Vec<Option<f64>> = eager_out
+            .column("x")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .iter()
+            .collect();
+        let lazy_vals: Vec<Option<f64>> = lazy_out
+            .column("x")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .iter()
+            .collect();
+
+        assert_eq!(eager_vals.len(), lazy_vals.len());
+        for i in 0..eager_vals.len() {
+            match (eager_vals[i], lazy_vals[i]) {
+                (Some(ev), Some(lv)) => {
+                    if ev.is_nan() {
+                        assert!(lv.is_nan());
+                    } else {
+                        assert_relative_eq!(ev, lv, epsilon = 1e-6);
+                    }
+                }
+                (None, None) => {}
+                _ => panic!(
+                    "Mismatch at index {}: eager={:?}, lazy={:?}",
+                    i, eager_vals[i], lazy_vals[i]
+                ),
+            }
+        }
     }
 }

--- a/src/preprocessing/encoder.rs
+++ b/src/preprocessing/encoder.rs
@@ -5,7 +5,7 @@
 //! - [`LabelEncoder`] — encode labels as `0..n_classes-1` integers
 //! - [`OrdinalEncoder`] — encode categorical features as integer columns
 
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, Fit, FitLazy, Result, Transform, TransformLazy};
 use polars::prelude::*;
 use std::collections::HashMap;
 
@@ -192,6 +192,9 @@ impl Transform<DataFrame> for OneHotEncoder {
     }
 }
 
+impl FitLazy for OneHotEncoder {}
+impl TransformLazy for OneHotEncoder {}
+
 /// Encode labels as integers `0` to `n_classes - 1`.
 ///
 /// Operates on a single string column. The mapping is sorted alphabetically.
@@ -309,6 +312,9 @@ impl Transform<DataFrame> for LabelEncoder {
             .map_err(|e| Error::Computation(e.to_string()))
     }
 }
+
+impl FitLazy for LabelEncoder {}
+impl TransformLazy for LabelEncoder {}
 
 /// Encode categorical features as integer columns.
 ///
@@ -449,6 +455,9 @@ impl Transform<DataFrame> for OrdinalEncoder {
         DataFrame::new(x.height(), out_cols).map_err(|e| Error::Computation(e.to_string()))
     }
 }
+
+impl FitLazy for OrdinalEncoder {}
+impl TransformLazy for OrdinalEncoder {}
 
 #[cfg(test)]
 mod tests {

--- a/src/preprocessing/feature_hasher.rs
+++ b/src/preprocessing/feature_hasher.rs
@@ -7,7 +7,7 @@
 //! (`+1.0` / `-1.0`) of each addition, so the expected value of every bucket
 //! is zero and collisions do not bias the mean.
 
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, Fit, FitLazy, Result, Transform, TransformLazy};
 use polars::prelude::*;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -145,6 +145,9 @@ impl Transform<DataFrame> for FeatureHasher {
         DataFrame::new(n_rows, out_cols).map_err(|e| Error::Computation(e.to_string()))
     }
 }
+
+impl FitLazy for FeatureHasher {}
+impl TransformLazy for FeatureHasher {}
 
 #[cfg(test)]
 mod tests {

--- a/src/preprocessing/imputer.rs
+++ b/src/preprocessing/imputer.rs
@@ -3,7 +3,7 @@
 //! [`SimpleImputer`] replaces missing (`None` / `null`) values with
 //! a statistic computed from the non-missing values in each column.
 
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, Fit, FitLazy, Result, Transform, TransformLazy};
 use polars::prelude::*;
 use std::collections::HashMap;
 
@@ -228,6 +228,9 @@ impl Transform<DataFrame> for SimpleImputer {
         Ok(out)
     }
 }
+
+impl FitLazy for SimpleImputer {}
+impl TransformLazy for SimpleImputer {}
 
 #[cfg(test)]
 mod tests {

--- a/src/preprocessing/missing_indicator.rs
+++ b/src/preprocessing/missing_indicator.rs
@@ -4,7 +4,7 @@
 //! were missing (null / `None`) in the original data. Useful for
 //! informing models about missingness patterns.
 
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, Fit, FitLazy, Result, Transform, TransformLazy};
 use polars::prelude::*;
 
 /// Add binary indicator columns for missing values.
@@ -119,6 +119,9 @@ impl Transform<DataFrame> for MissingIndicator {
         Ok(out)
     }
 }
+
+impl FitLazy for MissingIndicator {}
+impl TransformLazy for MissingIndicator {}
 
 #[cfg(test)]
 mod tests {

--- a/src/preprocessing/normalizer.rs
+++ b/src/preprocessing/normalizer.rs
@@ -69,10 +69,11 @@ impl Normalizer {
     }
 
     fn row_norm(values: &[f64], norm: Norm) -> f64 {
+        let clean_vals = values.iter().copied().filter(|v| !v.is_nan());
         match norm {
-            Norm::L1 => values.iter().map(|v| v.abs()).sum(),
-            Norm::L2 => values.iter().map(|v| v * v).sum::<f64>().sqrt(),
-            Norm::Max => values.iter().map(|v| v.abs()).fold(0.0f64, f64::max),
+            Norm::L1 => clean_vals.map(|v| v.abs()).sum(),
+            Norm::L2 => clean_vals.map(|v| v * v).sum::<f64>().sqrt(),
+            Norm::Max => clean_vals.map(|v| v.abs()).fold(0.0f64, f64::max),
         }
     }
 }
@@ -125,7 +126,7 @@ impl Transform<DataFrame> for Normalizer {
         let n_rows = x.height();
         let col_names: Vec<&str> = x.get_column_names().iter().map(|s| s.as_str()).collect();
 
-        let mut col_data: Vec<Vec<f64>> = Vec::with_capacity(n_cols);
+        let mut col_data: Vec<Vec<Option<f64>>> = Vec::with_capacity(n_cols);
         for name in &col_names {
             let s = x.column(name).map_err(|e| {
                 Error::InvalidInput(format!(
@@ -141,24 +142,34 @@ impl Transform<DataFrame> for Normalizer {
                     e
                 ))
             })?;
-            col_data.push(ca.iter().flatten().collect());
+            col_data.push(ca.iter().collect());
         }
 
         for i in 0..n_rows {
-            let row_vals: Vec<f64> = col_data.iter().map(|col| col[i]).collect();
+            let row_vals: Vec<f64> = col_data
+                .iter()
+                .filter_map(|col| col[i])
+                .collect();
             let norm = Self::row_norm(&row_vals, self.norm);
             if norm > f64::EPSILON {
                 for col in &mut col_data {
-                    col[i] /= norm;
+                    if let Some(v) = col[i].as_mut() {
+                        if !v.is_nan() {
+                            *v /= norm;
+                        }
+                    }
                 }
             }
         }
 
         let mut out_cols: Vec<Column> = Vec::with_capacity(n_cols);
         for (j, name) in col_names.iter().enumerate() {
-            let new_ca: ChunkedArray<Float64Type> =
-                ChunkedArray::from_slice(name.to_string().as_str().into(), &col_data[j]);
-            out_cols.push(new_ca.into_series().into());
+            let new_ca: ChunkedArray<Float64Type> = col_data[j]
+                .iter()
+                .copied()
+                .collect();
+            let s = new_ca.into_series().with_name(name.to_string().as_str().into());
+            out_cols.push(s.into());
         }
 
         DataFrame::new(n_rows, out_cols).map_err(|e| Error::Computation(e.to_string()))
@@ -243,5 +254,31 @@ mod tests {
         // Row 1 [1, 2]: norm = max(|1|, |2|) = 2.0  -> [0.5, 1.0]
         assert_relative_eq!(col_a.get(1).unwrap(), 0.5, epsilon = 1e-6);
         assert_relative_eq!(col_b.get(1).unwrap(), 1.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_normalizer_with_null_and_nan() {
+        // Row 0: [3.0, 4.0] -> norm L2 is 5.0 -> [0.6, 0.8]
+        // Row 1: [null, 6.0] -> norm L2 is 6.0 -> [null, 1.0]
+        // Row 2: [5.0, NaN] -> norm L2 is 5.0 -> [1.0, NaN]
+        let a = Column::from(Series::new("a".into(), &[Some(3.0f64), None, Some(5.0)]));
+        let b = Column::from(Series::new("b".into(), &[Some(4.0f64), Some(6.0), Some(f64::NAN)]));
+        let df = DataFrame::new(3, vec![a, b]).unwrap();
+
+        let mut n = Normalizer::l2();
+        n.fit(df.clone()).unwrap();
+        let result = n.transform(df).unwrap();
+
+        let col_a = result.column("a").unwrap().f64().unwrap();
+        let col_b = result.column("b").unwrap().f64().unwrap();
+
+        assert_relative_eq!(col_a.get(0).unwrap(), 0.6, epsilon = 1e-6);
+        assert_relative_eq!(col_b.get(0).unwrap(), 0.8, epsilon = 1e-6);
+
+        assert!(col_a.get(1).is_none());
+        assert_relative_eq!(col_b.get(1).unwrap(), 1.0, epsilon = 1e-6);
+
+        assert_relative_eq!(col_a.get(2).unwrap(), 1.0, epsilon = 1e-6);
+        assert!(col_b.get(2).unwrap().is_nan());
     }
 }

--- a/src/preprocessing/normalizer.rs
+++ b/src/preprocessing/normalizer.rs
@@ -146,10 +146,7 @@ impl Transform<DataFrame> for Normalizer {
         }
 
         for i in 0..n_rows {
-            let row_vals: Vec<f64> = col_data
-                .iter()
-                .filter_map(|col| col[i])
-                .collect();
+            let row_vals: Vec<f64> = col_data.iter().filter_map(|col| col[i]).collect();
             let norm = Self::row_norm(&row_vals, self.norm);
             if norm > f64::EPSILON {
                 for col in &mut col_data {
@@ -164,11 +161,10 @@ impl Transform<DataFrame> for Normalizer {
 
         let mut out_cols: Vec<Column> = Vec::with_capacity(n_cols);
         for (j, name) in col_names.iter().enumerate() {
-            let new_ca: ChunkedArray<Float64Type> = col_data[j]
-                .iter()
-                .copied()
-                .collect();
-            let s = new_ca.into_series().with_name(name.to_string().as_str().into());
+            let new_ca: ChunkedArray<Float64Type> = col_data[j].iter().copied().collect();
+            let s = new_ca
+                .into_series()
+                .with_name(name.to_string().as_str().into());
             out_cols.push(s.into());
         }
 
@@ -262,7 +258,10 @@ mod tests {
         // Row 1: [null, 6.0] -> norm L2 is 6.0 -> [null, 1.0]
         // Row 2: [5.0, NaN] -> norm L2 is 5.0 -> [1.0, NaN]
         let a = Column::from(Series::new("a".into(), &[Some(3.0f64), None, Some(5.0)]));
-        let b = Column::from(Series::new("b".into(), &[Some(4.0f64), Some(6.0), Some(f64::NAN)]));
+        let b = Column::from(Series::new(
+            "b".into(),
+            &[Some(4.0f64), Some(6.0), Some(f64::NAN)],
+        ));
         let df = DataFrame::new(3, vec![a, b]).unwrap();
 
         let mut n = Normalizer::l2();

--- a/src/preprocessing/normalizer.rs
+++ b/src/preprocessing/normalizer.rs
@@ -153,10 +153,10 @@ impl Transform<DataFrame> for Normalizer {
             let norm = Self::row_norm(&row_vals, self.norm);
             if norm > f64::EPSILON {
                 for col in &mut col_data {
-                    if let Some(v) = col[i].as_mut() {
-                        if !v.is_nan() {
-                            *v /= norm;
-                        }
+                    if let Some(v) = col[i].as_mut()
+                        && !v.is_nan()
+                    {
+                        *v /= norm;
                     }
                 }
             }

--- a/src/preprocessing/normalizer.rs
+++ b/src/preprocessing/normalizer.rs
@@ -3,7 +3,7 @@
 //! [`Normalizer`] scales each row (sample) to unit norm independently.
 //! Supports L1, L2, and Max norms. Analogous to `sklearn.preprocessing.Normalizer`.
 
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, Fit, FitLazy, Result, Transform, TransformLazy};
 use polars::prelude::*;
 
 /// Normalize samples individually to unit norm.
@@ -171,6 +171,9 @@ impl Transform<DataFrame> for Normalizer {
         DataFrame::new(n_rows, out_cols).map_err(|e| Error::Computation(e.to_string()))
     }
 }
+
+impl FitLazy for Normalizer {}
+impl TransformLazy for Normalizer {}
 
 #[cfg(test)]
 mod tests {

--- a/src/preprocessing/polynomial_features.rs
+++ b/src/preprocessing/polynomial_features.rs
@@ -4,7 +4,7 @@
 //! input features up to a specified degree. Analogous to
 //! `sklearn.preprocessing.PolynomialFeatures`.
 
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, Fit, FitLazy, Result, Transform, TransformLazy};
 use crate::util::require_f64_columns;
 use polars::prelude::*;
 
@@ -376,6 +376,9 @@ impl Transform<DataFrame> for PolynomialFeatures {
             .map_err(|e| Error::Computation(format!("failed to create polynomial features: {}", e)))
     }
 }
+
+impl FitLazy for PolynomialFeatures {}
+impl TransformLazy for PolynomialFeatures {}
 
 #[cfg(test)]
 mod tests {

--- a/src/preprocessing/scaler.rs
+++ b/src/preprocessing/scaler.rs
@@ -110,19 +110,32 @@ impl Fit<DataFrame> for StandardScaler {
                 ))
             })?;
 
+            let vals: Vec<f64> = _ca
+                .iter()
+                .flatten()
+                .filter(|v| !v.is_nan())
+                .collect();
+
+            if vals.is_empty() {
+                return Err(Error::Computation(format!(
+                    "StandardScaler: column '{}' has no non-null, non-NaN values. \
+                     Cannot scale an all-null or all-NaN column. Impute first or drop the column.",
+                    name
+                )));
+            }
+
             let col_mean = if self.with_mean {
-                _ca.mean().unwrap_or(0.0)
+                vals.iter().sum::<f64>() / vals.len() as f64
             } else {
                 0.0
             };
 
             let col_std = if self.with_std {
-                let var = _ca
+                let var = vals
                     .iter()
-                    .flatten()
                     .map(|v| (v - col_mean).powi(2))
                     .sum::<f64>()
-                    / _ca.len() as f64;
+                    / vals.len() as f64;
                 var.sqrt()
             } else {
                 1.0
@@ -444,7 +457,14 @@ impl Fit<DataFrame> for RobustScaler {
                     e
                 ))
             })?;
-            let mut vals: Vec<f64> = ca.iter().flatten().collect();
+            let mut vals: Vec<f64> = ca.iter().flatten().filter(|v| !v.is_nan()).collect();
+            if vals.is_empty() {
+                return Err(Error::Computation(format!(
+                    "RobustScaler: column '{}' has no non-null, non-NaN values. \
+                     Cannot scale an all-null or all-NaN column. Impute first or drop the column.",
+                    name
+                )));
+            }
             vals.sort_by(|a, b| a.total_cmp(b));
 
             let median = percentile_sorted(&vals, 50.0);
@@ -655,5 +675,50 @@ mod tests {
         // fit must not panic on the NaN-bearing sort.
         scaler.fit(df.clone()).unwrap();
         let _ = scaler.transform(df).unwrap();
+    }
+
+    #[test]
+    fn test_standard_scaler_partial_null_and_nan() {
+        // Values: 1.0, null, NaN, 5.0. Mean is 3.0.
+        // Variance: ((1.0-3.0)^2 + (5.0-3.0)^2) / 2 = (4 + 4) / 2 = 4.0.
+        // Std: 2.0.
+        // Transform of 1.0 -> -1.0. Transform of 5.0 -> 1.0.
+        let x = Column::from(Series::new("x".into(), &[Some(1.0f64), None, Some(f64::NAN), Some(5.0)]));
+        let df = DataFrame::new(4, vec![x]).unwrap();
+        let mut scaler = StandardScaler::new();
+        scaler.fit(df.clone()).unwrap();
+        let res = scaler.transform(df).unwrap();
+        let ca = res.column("x").unwrap().f64().unwrap();
+        let vals: Vec<Option<f64>> = ca.iter().collect();
+        assert_relative_eq!(vals[0].unwrap(), -1.0, epsilon = 1e-6);
+        assert!(vals[1].is_none());
+        assert!(vals[2].unwrap().is_nan());
+        assert_relative_eq!(vals[3].unwrap(), 1.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_standard_scaler_all_null_and_nan_errors() {
+        let x = Column::from(Series::new("x".into(), &[None::<f64>, None]));
+        let df = DataFrame::new(2, vec![x]).unwrap();
+        let mut scaler = StandardScaler::new();
+        assert!(scaler.fit(df).is_err());
+
+        let x = Column::from(Series::new("x".into(), &[f64::NAN, f64::NAN]));
+        let df = DataFrame::new(2, vec![x]).unwrap();
+        let mut scaler = StandardScaler::new();
+        assert!(scaler.fit(df).is_err());
+    }
+
+    #[test]
+    fn test_robust_scaler_all_null_and_nan_errors() {
+        let x = Column::from(Series::new("x".into(), &[None::<f64>, None]));
+        let df = DataFrame::new(2, vec![x]).unwrap();
+        let mut scaler = RobustScaler::new();
+        assert!(scaler.fit(df).is_err());
+
+        let x = Column::from(Series::new("x".into(), &[f64::NAN, f64::NAN]));
+        let df = DataFrame::new(2, vec![x]).unwrap();
+        let mut scaler = RobustScaler::new();
+        assert!(scaler.fit(df).is_err());
     }
 }

--- a/src/preprocessing/scaler.rs
+++ b/src/preprocessing/scaler.rs
@@ -110,49 +110,22 @@ impl Fit<DataFrame> for StandardScaler {
                 ))
             })?;
 
-<<<<<<< HEAD
-            let vals: Vec<f64> = _ca
-                .iter()
-                .flatten()
-                .filter(|v| !v.is_nan())
-                .collect();
-
-            if vals.is_empty() {
-                return Err(Error::Computation(format!(
-                    "StandardScaler: column '{}' has no non-null, non-NaN values. \
-=======
             let vals: Vec<f64> = _ca.iter().flatten().filter(|v| v.is_finite()).collect();
 
             if vals.is_empty() {
                 return Err(Error::Computation(format!(
                     "StandardScaler: column '{}' has no non-null, finite values. \
->>>>>>> upstream/main
                      Cannot scale an all-null or all-NaN column. Impute first or drop the column.",
                     name
                 )));
             }
 
-<<<<<<< HEAD
-            let col_mean = if self.with_mean {
-                vals.iter().sum::<f64>() / vals.len() as f64
-            } else {
-                0.0
-            };
-
-            let col_std = if self.with_std {
-                let var = vals
-                    .iter()
-                    .map(|v| (v - col_mean).powi(2))
-                    .sum::<f64>()
-                    / vals.len() as f64;
-=======
             let fitted_mean = vals.iter().sum::<f64>() / vals.len() as f64;
             let col_mean = if self.with_mean { fitted_mean } else { 0.0 };
 
             let col_std = if self.with_std {
                 let var =
                     vals.iter().map(|v| (v - fitted_mean).powi(2)).sum::<f64>() / vals.len() as f64;
->>>>>>> upstream/main
                 var.sqrt()
             } else {
                 1.0
@@ -474,26 +447,16 @@ impl Fit<DataFrame> for RobustScaler {
                     e
                 ))
             })?;
-<<<<<<< HEAD
-            let mut vals: Vec<f64> = ca.iter().flatten().filter(|v| !v.is_nan()).collect();
-            if vals.is_empty() {
-                return Err(Error::Computation(format!(
-                    "RobustScaler: column '{}' has no non-null, non-NaN values. \
-=======
             let mut vals: Vec<f64> = ca.iter().flatten().filter(|v| v.is_finite()).collect();
 
             if vals.is_empty() {
                 return Err(Error::Computation(format!(
                     "RobustScaler: column '{}' has no non-null, finite values. \
->>>>>>> upstream/main
                      Cannot scale an all-null or all-NaN column. Impute first or drop the column.",
                     name
                 )));
             }
-<<<<<<< HEAD
-=======
 
->>>>>>> upstream/main
             vals.sort_by(|a, b| a.total_cmp(b));
 
             let median = percentile_sorted(&vals, 50.0);
@@ -706,51 +669,6 @@ mod tests {
         let _ = scaler.transform(df).unwrap();
     }
 
-<<<<<<< HEAD
-    #[test]
-    fn test_standard_scaler_partial_null_and_nan() {
-        // Values: 1.0, null, NaN, 5.0. Mean is 3.0.
-        // Variance: ((1.0-3.0)^2 + (5.0-3.0)^2) / 2 = (4 + 4) / 2 = 4.0.
-        // Std: 2.0.
-        // Transform of 1.0 -> -1.0. Transform of 5.0 -> 1.0.
-        let x = Column::from(Series::new("x".into(), &[Some(1.0f64), None, Some(f64::NAN), Some(5.0)]));
-        let df = DataFrame::new(4, vec![x]).unwrap();
-        let mut scaler = StandardScaler::new();
-        scaler.fit(df.clone()).unwrap();
-        let res = scaler.transform(df).unwrap();
-        let ca = res.column("x").unwrap().f64().unwrap();
-        let vals: Vec<Option<f64>> = ca.iter().collect();
-        assert_relative_eq!(vals[0].unwrap(), -1.0, epsilon = 1e-6);
-        assert!(vals[1].is_none());
-        assert!(vals[2].unwrap().is_nan());
-        assert_relative_eq!(vals[3].unwrap(), 1.0, epsilon = 1e-6);
-    }
-
-    #[test]
-    fn test_standard_scaler_all_null_and_nan_errors() {
-        let x = Column::from(Series::new("x".into(), &[None::<f64>, None]));
-        let df = DataFrame::new(2, vec![x]).unwrap();
-        let mut scaler = StandardScaler::new();
-        assert!(scaler.fit(df).is_err());
-
-        let x = Column::from(Series::new("x".into(), &[f64::NAN, f64::NAN]));
-        let df = DataFrame::new(2, vec![x]).unwrap();
-        let mut scaler = StandardScaler::new();
-        assert!(scaler.fit(df).is_err());
-    }
-
-    #[test]
-    fn test_robust_scaler_all_null_and_nan_errors() {
-        let x = Column::from(Series::new("x".into(), &[None::<f64>, None]));
-        let df = DataFrame::new(2, vec![x]).unwrap();
-        let mut scaler = RobustScaler::new();
-        assert!(scaler.fit(df).is_err());
-
-        let x = Column::from(Series::new("x".into(), &[f64::NAN, f64::NAN]));
-        let df = DataFrame::new(2, vec![x]).unwrap();
-        let mut scaler = RobustScaler::new();
-        assert!(scaler.fit(df).is_err());
-=======
     /// Regression for #35: an all-null column must error at `fit` time instead
     /// of silently fitting with NaN parameters.
     #[test]
@@ -859,6 +777,5 @@ mod tests {
             "NaN input must map to NaN through transform"
         );
         assert_relative_eq!(vals[2].unwrap(), 1.0, epsilon = 1e-6);
->>>>>>> upstream/main
     }
 }

--- a/src/preprocessing/scaler.rs
+++ b/src/preprocessing/scaler.rs
@@ -4,16 +4,25 @@
 //! - [`StandardScaler`] — z-score normalization
 //! - [`MinMaxScaler`] — min-max scaling to a range
 //! - [`RobustScaler`] — scaling robust to outliers via IQR
+//!
+//! All three scalers implement [`TransformLazy`]
+//! with zero-copy Polars expressions, so they integrate into lazy pipelines
+//! without materializing intermediate `DataFrame`s.
 
 use polars::prelude::*;
 
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, Fit, FitLazy, Result, Transform, TransformLazy};
 use crate::util::{replace_f64_column, require_f64_columns};
 
 /// Standardize features by removing the mean and scaling to unit variance.
 ///
 /// For each column `x`, computes `(x - mean) / std` where `mean` and `std`
-/// are learned from the training data.
+/// are learned from the training data. Null values are preserved as-is;
+/// non-finite values (`NaN` / `±Inf`) are included in the statistics.
+///
+/// Implements [`TransformLazy`] with the lazy
+/// expression `(col - mean) / std`, which Polars can fuse with downstream
+/// filters and selects without materializing an intermediate `DataFrame`.
 ///
 /// # Example
 ///
@@ -184,6 +193,38 @@ impl Transform<DataFrame> for StandardScaler {
     }
 }
 
+impl FitLazy for StandardScaler {}
+
+impl TransformLazy for StandardScaler {
+    fn transform_lazy(&self, x: LazyFrame) -> Result<LazyFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted(
+                "StandardScaler has not been fitted. \
+                 Call .fit(dataframe) before .transform()."
+                    .into(),
+            ));
+        }
+
+        let params = self.params.as_ref().ok_or_else(|| {
+            Error::NotFitted(
+                "StandardScaler has not been fitted. \
+                 Call .fit(dataframe) before .transform()."
+                    .into(),
+            )
+        })?;
+
+        let mut exprs = Vec::with_capacity(params.len());
+        for p in params {
+            let name = p.name.as_str();
+            let mean = p.mean;
+            let std = p.std;
+            exprs.push((col(name) - lit(mean)) / lit(std));
+        }
+
+        Ok(x.with_columns(exprs))
+    }
+}
+
 /// Scale features to a given range (default `[0, 1]`).
 ///
 /// For each column `x`, computes `(x - min) / (max - min) * range + range_min`.
@@ -335,6 +376,38 @@ impl Transform<DataFrame> for MinMaxScaler {
         }
 
         Ok(out)
+    }
+}
+
+impl FitLazy for MinMaxScaler {}
+
+impl TransformLazy for MinMaxScaler {
+    fn transform_lazy(&self, x: LazyFrame) -> Result<LazyFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted(
+                "MinMaxScaler has not been fitted. \
+                 Call .fit(dataframe) before .transform()."
+                    .into(),
+            ));
+        }
+        let r_min = self.feature_range.0;
+        let params = self.params.as_ref().ok_or_else(|| {
+            Error::NotFitted(
+                "MinMaxScaler has not been fitted. \
+                 Call .fit(dataframe) before .transform()."
+                    .into(),
+            )
+        })?;
+
+        let mut exprs = Vec::with_capacity(params.len());
+        for p in params {
+            let name = p.name.as_str();
+            let min = p.min;
+            let scale = p.scale;
+            exprs.push((col(name) - lit(min)) * lit(scale) + lit(r_min));
+        }
+
+        Ok(x.with_columns(exprs))
     }
 }
 
@@ -511,6 +584,37 @@ impl Transform<DataFrame> for RobustScaler {
         }
 
         Ok(out)
+    }
+}
+
+impl FitLazy for RobustScaler {}
+
+impl TransformLazy for RobustScaler {
+    fn transform_lazy(&self, x: LazyFrame) -> Result<LazyFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted(
+                "RobustScaler has not been fitted. \
+                 Call .fit(dataframe) before .transform()."
+                    .into(),
+            ));
+        }
+        let params = self.params.as_ref().ok_or_else(|| {
+            Error::NotFitted(
+                "RobustScaler has not been fitted. \
+                 Call .fit(dataframe) before .transform()."
+                    .into(),
+            )
+        })?;
+
+        let mut exprs = Vec::with_capacity(params.len());
+        for p in params {
+            let name = p.name.as_str();
+            let center = p.center;
+            let scale = p.scale;
+            exprs.push((col(name) - lit(center)) / lit(scale));
+        }
+
+        Ok(x.with_columns(exprs))
     }
 }
 
@@ -777,5 +881,43 @@ mod tests {
             "NaN input must map to NaN through transform"
         );
         assert_relative_eq!(vals[2].unwrap(), 1.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_lazy_scalers() {
+        let df = make_test_df();
+
+        // 1. StandardScaler
+        let mut std_scaler = StandardScaler::new();
+        std_scaler.fit(df.clone()).unwrap();
+        let eager_std = std_scaler.transform(df.clone()).unwrap();
+        let lazy_std = std_scaler
+            .transform_lazy(df.clone().lazy())
+            .unwrap()
+            .collect()
+            .unwrap();
+        assert_eq!(eager_std, lazy_std);
+
+        // 2. MinMaxScaler
+        let mut min_max = MinMaxScaler::new().feature_range((-1.0, 1.0));
+        min_max.fit(df.clone()).unwrap();
+        let eager_mm = min_max.transform(df.clone()).unwrap();
+        let lazy_mm = min_max
+            .transform_lazy(df.clone().lazy())
+            .unwrap()
+            .collect()
+            .unwrap();
+        assert_eq!(eager_mm, lazy_mm);
+
+        // 3. RobustScaler
+        let mut robust = RobustScaler::new();
+        robust.fit(df.clone()).unwrap();
+        let eager_rb = robust.transform(df.clone()).unwrap();
+        let lazy_rb = robust
+            .transform_lazy(df.clone().lazy())
+            .unwrap()
+            .collect()
+            .unwrap();
+        assert_eq!(eager_rb, lazy_rb);
     }
 }

--- a/src/time_series/cyclical.rs
+++ b/src/time_series/cyclical.rs
@@ -183,18 +183,44 @@ mod tests {
         // Test empty DataFrame
         let df_empty = DataFrame::empty();
         let mut enc = CyclicalEncoder::new(&["hour"], 24);
-        assert!(enc.fit(df_empty).is_err());
+        let err = enc.fit(df_empty).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidInput(ref msg) if msg.contains("received an empty DataFrame")),
+            "Expected Error::InvalidInput containing 'received an empty DataFrame', got: {:?}",
+            err
+        );
 
         // Test non-Float64 column type (Int32)
         let vals = Column::from(Series::new("hour".into(), &[0_i32, 6, 12, 18]));
         let df_int = DataFrame::new(4, vec![vals]).unwrap();
         let mut enc = CyclicalEncoder::new(&["hour"], 24);
-        assert!(enc.fit(df_int).is_err());
+        let err = enc.fit(df_int).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidInput(ref msg) if msg.contains("expected Float64")),
+            "Expected Error::InvalidInput containing 'expected Float64', got: {:?}",
+            err
+        );
 
         // Test missing column
         let vals = Column::from(Series::new("day".into(), &[1.0_f64, 2.0]));
         let df_wrong_col = DataFrame::new(2, vec![vals]).unwrap();
         let mut enc = CyclicalEncoder::new(&["hour"], 24);
-        assert!(enc.fit(df_wrong_col).is_err());
+        let err = enc.fit(df_wrong_col).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidInput(ref msg) if msg.contains("column 'hour' not found")),
+            "Expected Error::InvalidInput containing 'column 'hour' not found', got: {:?}",
+            err
+        );
+
+        // Test empty columns list regression test
+        let vals = Column::from(Series::new("hour".into(), &[0.0_f64, 6.0]));
+        let df = DataFrame::new(2, vec![vals]).unwrap();
+        let mut enc = CyclicalEncoder::new(&[], 24);
+        let err = enc.fit(df).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidInput(ref msg) if msg.contains("at least one column is required")),
+            "Expected Error::InvalidInput containing 'at least one column is required', got: {:?}",
+            err
+        );
     }
 }

--- a/src/time_series/cyclical.rs
+++ b/src/time_series/cyclical.rs
@@ -4,7 +4,7 @@
 //! to `sin` and `cos` components so that `23:00` and `01:00` are close
 //! in the encoded space.
 
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, Fit, FitLazy, Result, Transform, TransformLazy};
 use polars::prelude::*;
 
 /// Encode cyclical features with sin/cos transformation.
@@ -151,6 +151,9 @@ impl Transform<DataFrame> for CyclicalEncoder {
         Ok(out)
     }
 }
+
+impl FitLazy for CyclicalEncoder {}
+impl TransformLazy for CyclicalEncoder {}
 
 #[cfg(test)]
 mod tests {

--- a/src/time_series/cyclical.rs
+++ b/src/time_series/cyclical.rs
@@ -61,11 +61,31 @@ impl Fit<DataFrame> for CyclicalEncoder {
     type Output = ();
 
     fn fit(&mut self, x: DataFrame) -> Result<()> {
+        let n_cols = x.width();
+        if x.height() == 0 || n_cols == 0 {
+            return Err(Error::InvalidInput(
+                "CyclicalEncoder.fit received an empty DataFrame (0 rows or 0 columns). \
+                 Provide data with at least 1 row and 1 column."
+                    .into(),
+            ));
+        }
+        if self.columns.is_empty() {
+            return Err(Error::InvalidInput(
+                "CyclicalEncoder: at least one column is required.".into(),
+            ));
+        }
         for (col, _) in &self.columns {
-            if x.column(col.as_str()).is_err() {
+            let s = x.column(col.as_str()).map_err(|e| {
+                Error::InvalidInput(format!(
+                    "CyclicalEncoder: column '{}' not found. {}",
+                    col, e
+                ))
+            })?;
+            if s.dtype() != &DataType::Float64 {
                 return Err(Error::InvalidInput(format!(
-                    "CyclicalEncoder: column '{}' not found.",
-                    col
+                    "CyclicalEncoder: column '{}' has dtype {}; expected Float64.",
+                    col,
+                    s.dtype()
                 )));
             }
         }
@@ -156,5 +176,25 @@ mod tests {
         // hour 6 (90°): sin=1, cos=0
         assert_relative_eq!(sin.get(1).unwrap(), 1.0, epsilon = 1e-6);
         assert_relative_eq!(cos.get(1).unwrap(), 0.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_cyclical_fit_validation() {
+        // Test empty DataFrame
+        let df_empty = DataFrame::empty();
+        let mut enc = CyclicalEncoder::new(&["hour"], 24);
+        assert!(enc.fit(df_empty).is_err());
+
+        // Test non-Float64 column type (Int32)
+        let vals = Column::from(Series::new("hour".into(), &[0_i32, 6, 12, 18]));
+        let df_int = DataFrame::new(4, vec![vals]).unwrap();
+        let mut enc = CyclicalEncoder::new(&["hour"], 24);
+        assert!(enc.fit(df_int).is_err());
+
+        // Test missing column
+        let vals = Column::from(Series::new("day".into(), &[1.0_f64, 2.0]));
+        let df_wrong_col = DataFrame::new(2, vec![vals]).unwrap();
+        let mut enc = CyclicalEncoder::new(&["hour"], 24);
+        assert!(enc.fit(df_wrong_col).is_err());
     }
 }

--- a/src/time_series/diff.rs
+++ b/src/time_series/diff.rs
@@ -2,7 +2,7 @@
 //!
 //! [`Difference`] computes `x[t] - x[t - period]` and percentage change.
 
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, Fit, FitLazy, Result, Transform, TransformLazy};
 use polars::prelude::*;
 
 /// Compute differences and percentage changes.
@@ -135,6 +135,9 @@ impl Transform<DataFrame> for Difference {
         Ok(out)
     }
 }
+
+impl FitLazy for Difference {}
+impl TransformLazy for Difference {}
 
 #[cfg(test)]
 mod tests {

--- a/src/time_series/lag.rs
+++ b/src/time_series/lag.rs
@@ -3,7 +3,7 @@
 //! [`Lagger`] creates shifted copies of columns for use as features
 //! in forecasting models. Analogous to `df.shift()` in pandas.
 
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, Fit, FitLazy, Result, Transform, TransformLazy};
 use polars::prelude::*;
 use std::collections::HashSet;
 
@@ -117,6 +117,9 @@ impl Transform<DataFrame> for Lagger {
         Ok(out)
     }
 }
+
+impl FitLazy for Lagger {}
+impl TransformLazy for Lagger {}
 
 #[cfg(test)]
 mod tests {

--- a/src/time_series/rolling.rs
+++ b/src/time_series/rolling.rs
@@ -3,7 +3,7 @@
 //! [`RollingAggregator`] computes rolling mean, std, min, max, sum
 //! over a fixed window. Analogous to `df.rolling()` in pandas.
 
-use crate::traits::{Error, Fit, Result, Transform};
+use crate::traits::{Error, Fit, FitLazy, Result, Transform, TransformLazy};
 use polars::prelude::*;
 
 /// Rolling window function to apply.
@@ -164,6 +164,9 @@ impl Transform<DataFrame> for RollingAggregator {
         Ok(out)
     }
 }
+
+impl FitLazy for RollingAggregator {}
+impl TransformLazy for RollingAggregator {}
 
 #[cfg(test)]
 mod tests {

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,18 +1,32 @@
 //! Core traits and error types for the featrs library.
 //!
-//! The library is built around four traits that mirror the scikit-learn API:
+//! The library is built around six traits that mirror the scikit-learn API:
 //!
 //! - [`Fit`] — learn parameters from unsupervised data (`fit(X)`)
 //! - [`FitSupervised`] — learn parameters from data plus a target (`fit(X, y)`)
-//! - [`Transform`] — apply a learned transformation (`transform`)
-//! - [`FitTransform`] — convenience trait that provides a default
-//!   `fit_transform(X)` for any type implementing both [`Fit`] and [`Transform`]
+//! - [`Transform`] — apply a learned transformation (`transform(X)`)
+//! - [`FitTransform`] — convenience trait providing a default `fit_transform(X)` for any type
+//!   implementing both [`Fit`] and [`Transform`]
+//! - [`FitLazy`] — learn parameters from a Polars [`LazyFrame`] (defaults to collecting
+//!   and calling [`Fit`]; override for zero-copy lazy fit)
+//! - [`TransformLazy`] — apply a learned transformation to a [`LazyFrame`] (defaults to
+//!   collecting and calling [`Transform`]; override to add lazy expressions to the plan
+//!   without materializing data)
 //!
 //! Unsupervised transformers (scalers, encoders, imputers, …) implement
 //! [`Fit`]; the few supervised ones (e.g. `SelectKBest`) implement
 //! [`FitSupervised`] instead. This mirrors scikit-learn's split between
 //! `fit(X)` and `fit(X, y)`, so callers no longer pass a dummy target to
 //! unsupervised transformers.
+//!
+//! # Lazy execution
+//!
+//! Using [`FitLazy`] and [`TransformLazy`] allows pipelines to be expressed
+//! as Polars query plans. Polars can then fuse multiple column expressions,
+//! apply predicate pushdown, and execute everything in a single optimized
+//! pass when `.collect()` is called. Transformers that do not provide a custom
+//! override still work correctly — they simply collect the `LazyFrame` eagerly,
+//! apply their regular `transform`, and re-lazify the result.
 //!
 //! # Errors
 //!
@@ -126,6 +140,8 @@ pub trait Transform<X> {
     fn transform(&self, x: X) -> Result<Self::Output>;
 }
 
+use polars::prelude::{DataFrame, IntoLazy, LazyFrame};
+
 /// Convenience trait for types that implement both [`Fit`] and [`Transform`].
 ///
 /// Automatically implemented for any type satisfying both bounds. Provides a
@@ -149,3 +165,83 @@ pub trait FitTransform<X>: Fit<X> + Transform<X> {
 }
 
 impl<T, X> FitTransform<X> for T where T: Fit<X> + Transform<X> {}
+
+/// Learn parameters from unsupervised data in a lazy (query-planned) manner.
+///
+/// This is the lazy counterpart to [`Fit`]. The default implementation collects
+/// the [`LazyFrame`] into a [`DataFrame`] and delegates to [`Fit::fit`], so any
+/// transformer that implements [`Fit`] automatically gets a working `fit_lazy`
+/// without any extra code.
+///
+/// Override this method to keep the fit logic fully within the lazy query plan
+/// (e.g. running aggregations via lazy expressions and reading back only the
+/// statistics you need), which avoids materializing large intermediate frames.
+///
+/// # Example
+///
+/// ```rust
+/// use featrs::preprocessing::scaler::StandardScaler;
+/// use featrs::traits::{FitLazy, TransformLazy};
+/// use polars::prelude::{Column, DataFrame, IntoLazy, NamedFrom, Series};
+///
+/// let col = Column::from(Series::new("x".into(), &[1.0_f64, 2.0, 3.0]));
+/// let df = DataFrame::new(3, vec![col])?;
+///
+/// let mut scaler = StandardScaler::new();
+/// scaler.fit_lazy(df.clone().lazy())?;
+/// let result = scaler.transform_lazy(df.lazy())?.collect()?;
+/// assert_eq!(result.height(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub trait FitLazy: Fit<DataFrame, Output = ()> {
+    /// Fit the transformer to the lazy data.
+    ///
+    /// By default, this collects the [`LazyFrame`] and delegates to [`Fit::fit`].
+    /// Transformers can override this to run fit logic (or partial collection) on the query plan.
+    fn fit_lazy(&mut self, x: LazyFrame) -> Result<()> {
+        let df = x.collect().map_err(|e| Error::Computation(e.to_string()))?;
+        self.fit(df)
+    }
+}
+
+/// Apply a learned transformation to a lazy (query-planned) frame.
+///
+/// This is the lazy counterpart to [`Transform`]. The default implementation
+/// collects the [`LazyFrame`] into a [`DataFrame`], applies the eager
+/// [`Transform::transform`], and wraps the result back in a `LazyFrame`.
+///
+/// Override this method to build lazy Polars expressions instead of
+/// materializing data. An override should append `with_columns(exprs)` or
+/// `select(exprs)` to the incoming `LazyFrame` and return the resulting plan.
+/// Polars will then fuse those expressions with the rest of the pipeline and
+/// execute everything in a single optimized pass.
+///
+/// # Lazy-optimized implementations
+///
+/// The following transformers override `transform_lazy` with expression-based
+/// implementations that do not collect the `LazyFrame`:
+///
+/// | Transformer | Lazy expression |
+/// |---|---|
+/// | `StandardScaler` | `(col - mean) / std` |
+/// | `MinMaxScaler` | `(col - min) * scale + range_min` |
+/// | `RobustScaler` | `(col - center) / scale` |
+/// | `Binarizer` | `when(col > threshold).then(1.0).otherwise(0.0)` |
+/// | `VarianceThreshold` | `select(selected_cols)` |
+/// | `SelectKBest` | `select(selected_cols)` |
+///
+/// All other transformers fall back to the default (collect → eager transform
+/// → re-lazify). This means they still work correctly in a lazy pipeline but
+/// do not benefit from query-plan fusion.
+pub trait TransformLazy: Transform<DataFrame, Output = DataFrame> {
+    /// Transform the lazy data using the fitted parameters.
+    ///
+    /// By default, this collects the [`LazyFrame`], performs the eager transformation
+    /// via [`Transform::transform`], and returns the result lazily.
+    /// Transformers should override this to append lazy expressions to the `LazyFrame`.
+    fn transform_lazy(&self, x: LazyFrame) -> Result<LazyFrame> {
+        let df = x.collect().map_err(|e| Error::Computation(e.to_string()))?;
+        let transformed = self.transform(df)?;
+        Ok(transformed.lazy())
+    }
+}


### PR DESCRIPTION
Direct support for executing all transformers on Polars `LazyFrame`s.

**Changes:**
- Introduced `FitLazy` / `TransformLazy` traits.
- Implemented zero-copy lazy execution for:
  - `StandardScaler`, `MinMaxScaler`, `RobustScaler`
  - `Binarizer` (with correct `NaN` propagation)
  - `VarianceThreshold` and `SelectKBest`
- Added lazy execution support for composition in `Pipeline` and `ColumnTransformer`.
- Updated documentation and added unit tests covering all lazy implementations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lazy execution support for transformers, pipelines, and column-based transformations using Polars `LazyFrame`.
  * Added lazy fitting and transformation traits, available through the public prelude.
  * Added optimized lazy examples and documentation, including zero-copy transformations for supported components.
* **Bug Fixes**
  * Improved handling of null and `NaN` values in variance selection, normalization, and binarization.
  * Added clearer validation for cyclical encoding inputs.
* **Tests**
  * Added coverage confirming lazy results match eager transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->