### PR TITLE
feat(InteractionFeatures): pairwise interaction features (a·b without full polynomial expansion)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,8 @@ pub mod prelude {
     pub use crate::preprocessing::feature_hasher::FeatureHasher;
     pub use crate::preprocessing::imputer::SimpleImputer;
     pub use crate::preprocessing::imputer::Strategy;
+    pub use crate::preprocessing::interaction_features::InteractionFeatures;
+    pub use crate::preprocessing::interaction_features::InteractionFeaturesBuilder;
     pub use crate::preprocessing::missing_indicator::MissingIndicator;
     pub use crate::preprocessing::normalizer::Norm;
     pub use crate::preprocessing::normalizer::Normalizer;

--- a/src/preprocessing/interaction_features.rs
+++ b/src/preprocessing/interaction_features.rs
@@ -1,0 +1,550 @@
+//! Pairwise interaction feature generation.
+//!
+//! [`InteractionFeatures`] generates the element-wise product of every pair
+//! of input columns, without the pure-power terms (`a²`, `b²`, …) or
+//! higher-degree crosses (`a·b·c`) that [`PolynomialFeatures`] would
+//! produce. It is a focused alternative to
+//! `PolynomialFeatures::builder().degree(2).interaction_only(true).build()`,
+//! offered as a dedicated, more discoverable transformer.
+//!
+//! # Output semantics
+//!
+//! The original input columns are **preserved** and the new interaction
+//! columns are **appended** in column order. For input columns
+//! `[a, b, c]` (no self-products), the output columns are
+//! `[a, b, c, a_x_b, a_x_c, b_x_c]`.
+//!
+//! When [`include_self_products`](InteractionFeaturesBuilder::include_self_products)
+//! is enabled, pure-square terms are also emitted:
+//! `[a, b, c, a_x_a, a_x_b, a_x_c, b_x_b, b_x_c, c_x_c]`.
+//!
+//! Pairs are generated in the **order the columns appear** in the fitted
+//! column list (frame order for auto-discovered columns; the user-supplied
+//! order for explicit columns) — no lexicographic reordering is applied.
+//!
+//! [`PolynomialFeatures`]: crate::preprocessing::polynomial_features::PolynomialFeatures
+
+use crate::traits::{Error, Fit, Result, Transform};
+use crate::util::{numeric_f64_columns, series_mul};
+use polars::prelude::*;
+
+/// Suffix inserted between the names of the two factor columns to form an
+/// interaction column name (e.g. `a_x_b`).
+///
+/// Note: if an input column name itself contains `_x_`, the generated name
+/// may be ambiguous. Callers in such cases should rename their inputs before
+/// fitting.
+const NAME_SEP: &str = "_x_";
+
+/// Generate pairwise interaction features (`a·b`) without the full
+/// polynomial expansion.
+///
+/// Stateful only in the sense that it remembers which columns to operate
+/// on; no numeric parameters are learned. Implements [`Fit`] and
+/// [`Transform`] on [`DataFrame`].
+///
+/// # Example
+///
+/// ```rust
+/// use featrs::preprocessing::interaction_features::InteractionFeatures;
+/// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let a = Column::from(Series::new("a".into(), &[1.0_f64, 2.0, 3.0]));
+/// let b = Column::from(Series::new("b".into(), &[4.0_f64, 5.0, 6.0]));
+/// let df = DataFrame::new(3, vec![a, b])?;
+///
+/// let mut xf = InteractionFeatures::builder().build();
+/// xf.fit(df.clone())?;
+/// let out = xf.transform(df)?;
+/// // a, b, a_x_b = [4.0, 10.0, 18.0]
+/// assert_eq!(out.width(), 3);
+/// assert_eq!(out.column("a_x_b")?.f64()?.get(1).unwrap(), 10.0);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub struct InteractionFeatures {
+    fitted: bool,
+    columns: Vec<String>,
+    include_self_products: bool,
+}
+
+impl InteractionFeatures {
+    /// Create a new transformer with auto-discovered columns and
+    /// `include_self_products = false`.
+    ///
+    /// Equivalent to
+    /// [`InteractionFeatures::builder().build()`](InteractionFeaturesBuilder::build).
+    pub fn new() -> Self {
+        Self {
+            fitted: false,
+            columns: vec![],
+            include_self_products: false,
+        }
+    }
+
+    /// Begin builder configuration.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use featrs::preprocessing::interaction_features::InteractionFeatures;
+    ///
+    /// let _xf = InteractionFeatures::builder()
+    ///     .columns(&["a", "b"])
+    ///     .include_self_products(true)
+    ///     .build();
+    /// ```
+    pub fn builder() -> InteractionFeaturesBuilder {
+        InteractionFeaturesBuilder::default()
+    }
+}
+
+impl Default for InteractionFeatures {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Builder for [`InteractionFeatures`].
+///
+/// Provides a more ergonomic way to configure interaction feature
+/// generation, mirroring the [`PolynomialFeaturesBuilder`] pattern.
+///
+/// [`PolynomialFeaturesBuilder`]: crate::preprocessing::polynomial_features::PolynomialFeaturesBuilder
+#[derive(Default)]
+pub struct InteractionFeaturesBuilder {
+    columns: Option<Vec<String>>,
+    include_self_products: bool,
+}
+
+impl InteractionFeaturesBuilder {
+    /// Restrict interaction generation to the named columns.
+    ///
+    /// When omitted, [`build`](InteractionFeaturesBuilder::build) produces a
+    /// transformer that auto-discovers all `Float64` columns at [`Fit`]
+    /// time.
+    ///
+    /// Each column must exist in the frame passed to `fit` and have dtype
+    /// `Float64`; otherwise `fit` returns
+    /// [`Error::InvalidInput`].
+    pub fn columns(mut self, cols: &[&str]) -> Self {
+        self.columns = Some(cols.iter().map(|s| s.to_string()).collect());
+        self
+    }
+
+    /// Whether to also emit pure-square terms (`a·a`, `b·b`, …).
+    ///
+    /// Default: `false` — only distinct pairs (`i < j`) are generated.
+    pub fn include_self_products(mut self, value: bool) -> Self {
+        self.include_self_products = value;
+        self
+    }
+
+    /// Build the [`InteractionFeatures`] instance.
+    ///
+    /// This never fails: invalid column selections surface at [`Fit`] time.
+    pub fn build(self) -> InteractionFeatures {
+        InteractionFeatures {
+            fitted: false,
+            columns: self.columns.unwrap_or_default(),
+            include_self_products: self.include_self_products,
+        }
+    }
+}
+
+impl Fit<DataFrame> for InteractionFeatures {
+    type Output = ();
+
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
+        if x.height() == 0 || x.width() == 0 {
+            return Err(Error::InvalidInput(
+                "InteractionFeatures.fit received an empty DataFrame (0 rows or 0 columns)."
+                    .into(),
+            ));
+        }
+
+        if self.columns.is_empty() {
+            let discovered = numeric_f64_columns(&x);
+            if discovered.is_empty() {
+                let all_types: Vec<String> = x
+                    .get_column_names()
+                    .iter()
+                    .filter_map(|n| {
+                        x.column(n)
+                            .ok()
+                            .map(|c| format!("'{n}' ({})", c.dtype()))
+                    })
+                    .collect();
+                return Err(Error::InvalidInput(format!(
+                    "InteractionFeatures: no Float64 columns found. This transformer only \
+                     operates on f64 columns. Available columns: [{}]. Cast non-f64 columns \
+                     before fitting.",
+                    all_types.join(", ")
+                )));
+            }
+            self.columns = discovered;
+        } else {
+            for col in &self.columns {
+                let c = x.column(col.as_str()).map_err(|e| {
+                    Error::InvalidInput(format!(
+                        "InteractionFeatures.fit: column '{col}' not found. {e}"
+                    ))
+                })?;
+                if c.dtype() != &DataType::Float64 {
+                    return Err(Error::InvalidInput(format!(
+                        "InteractionFeatures.fit: column '{col}' has dtype {}; expected Float64.",
+                        c.dtype()
+                    )));
+                }
+            }
+        }
+
+        self.fitted = true;
+        Ok(())
+    }
+}
+
+impl Transform<DataFrame> for InteractionFeatures {
+    type Output = DataFrame;
+
+    fn transform(&self, x: DataFrame) -> Result<DataFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted(
+                "InteractionFeatures has not been fitted. \
+                 Call .fit(dataframe) before .transform()."
+                    .into(),
+            ));
+        }
+
+        let mut out = x.clone();
+        let who = "InteractionFeatures";
+        let n = self.columns.len();
+
+        // (i, j) index pairs into the fitted column list.
+        // - default (no self products): j strictly greater than i
+        // - include_self_products: j >= i  (covers i==j squares)
+        let pairs: Vec<(usize, usize)> = (0..n)
+            .flat_map(|i| {
+                let start = if self.include_self_products { i } else { i + 1 };
+                (start..n).map(move |j| (i, j))
+            })
+            .collect();
+
+        for (i, j) in pairs {
+            let name_i = &self.columns[i];
+            let name_j = &self.columns[j];
+
+            let s_i = out
+                .column(name_i.as_str())
+                .map_err(|e| {
+                    Error::InvalidInput(format!(
+                        "{who}.transform: column '{name_i}' not found. The transformer was \
+                         fitted on columns: {:?}. {e}",
+                        self.columns
+                    ))
+                })?
+                .as_materialized_series()
+                .clone();
+            let s_j = out
+                .column(name_j.as_str())
+                .map_err(|e| {
+                    Error::InvalidInput(format!(
+                        "{who}.transform: column '{name_j}' not found. The transformer was \
+                         fitted on columns: {:?}. {e}",
+                        self.columns
+                    ))
+                })?
+                .as_materialized_series()
+                .clone();
+
+            let product = series_mul(&s_i, &s_j, who)?;
+            let out_name = format!("{name_i}{NAME_SEP}{name_j}");
+
+            let mut product = product;
+            product.rename(out_name.as_str().into());
+
+            out.with_column(product.into())
+                .map_err(|e| Error::Computation(format!("{who}.transform: {e}")))?;
+        }
+
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_two_col_df() -> DataFrame {
+        let a = Column::from(Series::new("a".into(), &[1.0_f64, 2.0, 3.0]));
+        let b = Column::from(Series::new("b".into(), &[4.0_f64, 5.0, 6.0]));
+        DataFrame::new(3, vec![a, b]).unwrap()
+    }
+
+    fn make_three_col_df() -> DataFrame {
+        let a = Column::from(Series::new("a".into(), &[1.0_f64, 2.0, 3.0]));
+        let b = Column::from(Series::new("b".into(), &[4.0_f64, 5.0, 6.0]));
+        let c = Column::from(Series::new("c".into(), &[7.0_f64, 8.0, 9.0]));
+        DataFrame::new(3, vec![a, b, c]).unwrap()
+    }
+
+    #[test]
+    fn test_interaction_two_columns_default() {
+        let df = make_two_col_df();
+        let mut xf = InteractionFeatures::builder().build();
+        xf.fit(df.clone()).unwrap();
+        let out = xf.transform(df).unwrap();
+
+        // originals: a, b  + new: a_x_b
+        assert_eq!(out.width(), 3);
+        assert_eq!(out.height(), 3);
+
+        let prod = out.column("a_x_b").unwrap().f64().unwrap();
+        assert_eq!(prod.get(0).unwrap(), 4.0);
+        assert_eq!(prod.get(1).unwrap(), 10.0);
+        assert_eq!(prod.get(2).unwrap(), 18.0);
+    }
+
+    #[test]
+    fn test_interaction_include_self_products() {
+        let df = make_two_col_df();
+        let mut xf = InteractionFeatures::builder()
+            .include_self_products(true)
+            .build();
+        xf.fit(df.clone()).unwrap();
+        let out = xf.transform(df).unwrap();
+
+        // a, b, a_x_a, a_x_b, b_x_b
+        assert_eq!(out.width(), 5);
+
+        let aa = out.column("a_x_a").unwrap().f64().unwrap();
+        assert_eq!(aa.get(0).unwrap(), 1.0);
+        assert_eq!(aa.get(1).unwrap(), 4.0);
+        assert_eq!(aa.get(2).unwrap(), 9.0);
+
+        let bb = out.column("b_x_b").unwrap().f64().unwrap();
+        assert_eq!(bb.get(0).unwrap(), 16.0);
+        assert_eq!(bb.get(1).unwrap(), 25.0);
+        assert_eq!(bb.get(2).unwrap(), 36.0);
+
+        // a_x_b still present
+        assert!(out.column("a_x_b").is_ok());
+    }
+
+    #[test]
+    fn test_interaction_three_columns_three_pairs() {
+        let df = make_three_col_df();
+        let mut xf = InteractionFeatures::builder().build();
+        xf.fit(df.clone()).unwrap();
+        let out = xf.transform(df).unwrap();
+
+        // a, b, c  +  a_x_b, a_x_c, b_x_c
+        assert_eq!(out.width(), 6);
+        assert!(out.column("a_x_b").is_ok());
+        assert!(out.column("a_x_c").is_ok());
+        assert!(out.column("b_x_c").is_ok());
+        // no self products
+        assert!(out.column("a_x_a").is_err());
+    }
+
+    #[test]
+    fn test_interaction_single_column_no_new_cols() {
+        let a = Column::from(Series::new("a".into(), &[1.0_f64, 2.0, 3.0]));
+        let df = DataFrame::new(3, vec![a]).unwrap();
+
+        let mut xf = InteractionFeatures::builder().build();
+        xf.fit(df.clone()).unwrap();
+        let out = xf.transform(df).unwrap();
+
+        // kept originals; no pairs generated
+        assert_eq!(out.width(), 1);
+        assert_eq!(out.height(), 3);
+    }
+
+    #[test]
+    fn test_interaction_single_column_self_products() {
+        let a = Column::from(Series::new("a".into(), &[1.0_f64, 2.0, 3.0]));
+        let df = DataFrame::new(3, vec![a]).unwrap();
+
+        let mut xf = InteractionFeatures::builder()
+            .include_self_products(true)
+            .build();
+        xf.fit(df.clone()).unwrap();
+        let out = xf.transform(df).unwrap();
+
+        // a, a_x_a
+        assert_eq!(out.width(), 2);
+        let aa = out.column("a_x_a").unwrap().f64().unwrap();
+        assert_eq!(aa.get(0).unwrap(), 1.0);
+        assert_eq!(aa.get(1).unwrap(), 4.0);
+        assert_eq!(aa.get(2).unwrap(), 9.0);
+    }
+
+    #[test]
+    fn test_interaction_null_propagation() {
+        let a =
+            Column::from(Series::new("a".into(), &[Some(1.0_f64), None, Some(3.0)]));
+        let b =
+            Column::from(Series::new("b".into(), &[Some(4.0_f64), Some(5.0), None]));
+        let df = DataFrame::new(3, vec![a, b]).unwrap();
+
+        let mut xf = InteractionFeatures::builder().build();
+        xf.fit(df.clone()).unwrap();
+        let out = xf.transform(df).unwrap();
+
+        let prod = out.column("a_x_b").unwrap().f64().unwrap();
+        assert_eq!(prod.get(0).unwrap(), 4.0);
+        assert!(prod.get(1).is_none()); // a null
+        assert!(prod.get(2).is_none()); // b null
+    }
+
+    #[test]
+    fn test_interaction_nan_propagation() {
+        let a = Column::from(Series::new("a".into(), &[1.0_f64, f64::NAN, 3.0]));
+        let b = Column::from(Series::new("b".into(), &[4.0_f64, 5.0, 6.0]));
+        let df = DataFrame::new(3, vec![a, b]).unwrap();
+
+        let mut xf = InteractionFeatures::builder().build();
+        xf.fit(df.clone()).unwrap();
+        let out = xf.transform(df).unwrap();
+
+        let prod = out.column("a_x_b").unwrap().f64().unwrap();
+        assert_eq!(prod.get(0).unwrap(), 4.0);
+        assert!(prod.get(1).unwrap().is_nan());
+        assert_eq!(prod.get(2).unwrap(), 18.0);
+    }
+
+    #[test]
+    fn test_interaction_not_fitted_error() {
+        let df = make_two_col_df();
+        let xf = InteractionFeatures::builder().build();
+        let err = xf.transform(df).unwrap_err();
+        assert!(matches!(err, Error::NotFitted(_)));
+    }
+
+    #[test]
+    fn test_interaction_auto_discovery_all_f64() {
+        let df = make_two_col_df();
+        let mut xf = InteractionFeatures::builder().build();
+        xf.fit(df.clone()).unwrap();
+        let out = xf.transform(df).unwrap();
+        // auto-discovered a, b → one pair
+        assert_eq!(out.width(), 3);
+    }
+
+    #[test]
+    fn test_interaction_auto_discovery_skips_non_f64() {
+        // mixed dtypes: only f64 columns participate
+        let a = Column::from(Series::new("a".into(), &[1.0_f64, 2.0, 3.0]));
+        let cat =
+            Column::from(Series::new("cat".into(), &["x", "y", "z"]));
+        let b = Column::from(Series::new("b".into(), &[4.0_f64, 5.0, 6.0]));
+        let df = DataFrame::new(3, vec![a, cat, b]).unwrap();
+
+        let mut xf = InteractionFeatures::builder().build();
+        xf.fit(df.clone()).unwrap();
+        let out = xf.transform(df).unwrap();
+
+        // a, cat, b  +  a_x_b   (cat skipped)
+        assert_eq!(out.width(), 4);
+        assert!(out.column("a_x_b").is_ok());
+    }
+
+    #[test]
+    fn test_interaction_auto_discovery_no_f64_errors() {
+        let cat =
+            Column::from(Series::new("cat".into(), &["x", "y", "z"]));
+        let df = DataFrame::new(3, vec![cat]).unwrap();
+
+        let mut xf = InteractionFeatures::builder().build();
+        let err = xf.fit(df).unwrap_err();
+        assert!(matches!(err, Error::InvalidInput(_)));
+    }
+
+    #[test]
+    fn test_interaction_explicit_columns() {
+        let df = make_three_col_df();
+        let mut xf = InteractionFeatures::builder()
+            .columns(&["a", "c"])
+            .build();
+        xf.fit(df.clone()).unwrap();
+        let out = xf.transform(df).unwrap();
+
+        // a, b, c  +  a_x_c   (b not selected)
+        assert_eq!(out.width(), 4);
+        assert!(out.column("a_x_c").is_ok());
+        assert!(out.column("a_x_b").is_err());
+    }
+
+    #[test]
+    fn test_interaction_explicit_missing_column_errors() {
+        let df = make_two_col_df();
+        let mut xf = InteractionFeatures::builder()
+            .columns(&["a", "missing"])
+            .build();
+        let err = xf.fit(df).unwrap_err();
+        assert!(matches!(err, Error::InvalidInput(_)));
+    }
+
+    #[test]
+    fn test_interaction_explicit_non_f64_column_errors() {
+        let a = Column::from(Series::new("a".into(), &[1.0_f64, 2.0, 3.0]));
+        let cat =
+            Column::from(Series::new("cat".into(), &["x", "y", "z"]));
+        let df = DataFrame::new(3, vec![a, cat]).unwrap();
+
+        let mut xf = InteractionFeatures::builder()
+            .columns(&["a", "cat"])
+            .build();
+        let err = xf.fit(df).unwrap_err();
+        assert!(matches!(err, Error::InvalidInput(_)));
+    }
+
+    #[test]
+    fn test_interaction_empty_dataframe_rejected() {
+        let df = DataFrame::empty();
+        let mut xf = InteractionFeatures::builder().build();
+        let err = xf.fit(df).unwrap_err();
+        assert!(matches!(err, Error::InvalidInput(_)));
+    }
+
+    #[test]
+    fn test_interaction_zero_column_propagates() {
+        // products involving an all-zero column are all zeros
+        let a = Column::from(Series::new("a".into(), &[1.0_f64, 2.0, 3.0]));
+        let z = Column::from(Series::new("z".into(), &[0.0_f64, 0.0, 0.0]));
+        let df = DataFrame::new(3, vec![a, z]).unwrap();
+
+        let mut xf = InteractionFeatures::builder().build();
+        xf.fit(df.clone()).unwrap();
+        let out = xf.transform(df).unwrap();
+
+        let prod = out.column("a_x_z").unwrap().f64().unwrap();
+        assert_eq!(prod.get(0).unwrap(), 0.0);
+        assert_eq!(prod.get(1).unwrap(), 0.0);
+        assert_eq!(prod.get(2).unwrap(), 0.0);
+    }
+
+    #[test]
+    fn test_interaction_column_order_preserved() {
+        // explicit column order [b, a] → pair name b_x_a, not a_x_b
+        let df = make_two_col_df();
+        let mut xf = InteractionFeatures::builder()
+            .columns(&["b", "a"])
+            .build();
+        xf.fit(df.clone()).unwrap();
+        let out = xf.transform(df).unwrap();
+
+        assert!(out.column("b_x_a").is_ok());
+        assert!(out.column("a_x_b").is_err());
+    }
+
+    #[test]
+    fn test_default_equals_new() {
+        let d = InteractionFeatures::default();
+        let n = InteractionFeatures::new();
+        assert_eq!(d.columns, n.columns);
+        assert_eq!(d.include_self_products, n.include_self_products);
+        assert_eq!(d.fitted, n.fitted);
+    }
+}

--- a/src/preprocessing/interaction_features.rs
+++ b/src/preprocessing/interaction_features.rs
@@ -158,8 +158,7 @@ impl Fit<DataFrame> for InteractionFeatures {
     fn fit(&mut self, x: DataFrame) -> Result<()> {
         if x.height() == 0 || x.width() == 0 {
             return Err(Error::InvalidInput(
-                "InteractionFeatures.fit received an empty DataFrame (0 rows or 0 columns)."
-                    .into(),
+                "InteractionFeatures.fit received an empty DataFrame (0 rows or 0 columns).".into(),
             ));
         }
 
@@ -169,11 +168,7 @@ impl Fit<DataFrame> for InteractionFeatures {
                 let all_types: Vec<String> = x
                     .get_column_names()
                     .iter()
-                    .filter_map(|n| {
-                        x.column(n)
-                            .ok()
-                            .map(|c| format!("'{n}' ({})", c.dtype()))
-                    })
+                    .filter_map(|n| x.column(n).ok().map(|c| format!("'{n}' ({})", c.dtype())))
                     .collect();
                 return Err(Error::InvalidInput(format!(
                     "InteractionFeatures: no Float64 columns found. This transformer only \
@@ -382,10 +377,8 @@ mod tests {
 
     #[test]
     fn test_interaction_null_propagation() {
-        let a =
-            Column::from(Series::new("a".into(), &[Some(1.0_f64), None, Some(3.0)]));
-        let b =
-            Column::from(Series::new("b".into(), &[Some(4.0_f64), Some(5.0), None]));
+        let a = Column::from(Series::new("a".into(), &[Some(1.0_f64), None, Some(3.0)]));
+        let b = Column::from(Series::new("b".into(), &[Some(4.0_f64), Some(5.0), None]));
         let df = DataFrame::new(3, vec![a, b]).unwrap();
 
         let mut xf = InteractionFeatures::builder().build();
@@ -436,8 +429,7 @@ mod tests {
     fn test_interaction_auto_discovery_skips_non_f64() {
         // mixed dtypes: only f64 columns participate
         let a = Column::from(Series::new("a".into(), &[1.0_f64, 2.0, 3.0]));
-        let cat =
-            Column::from(Series::new("cat".into(), &["x", "y", "z"]));
+        let cat = Column::from(Series::new("cat".into(), &["x", "y", "z"]));
         let b = Column::from(Series::new("b".into(), &[4.0_f64, 5.0, 6.0]));
         let df = DataFrame::new(3, vec![a, cat, b]).unwrap();
 
@@ -452,8 +444,7 @@ mod tests {
 
     #[test]
     fn test_interaction_auto_discovery_no_f64_errors() {
-        let cat =
-            Column::from(Series::new("cat".into(), &["x", "y", "z"]));
+        let cat = Column::from(Series::new("cat".into(), &["x", "y", "z"]));
         let df = DataFrame::new(3, vec![cat]).unwrap();
 
         let mut xf = InteractionFeatures::builder().build();
@@ -464,9 +455,7 @@ mod tests {
     #[test]
     fn test_interaction_explicit_columns() {
         let df = make_three_col_df();
-        let mut xf = InteractionFeatures::builder()
-            .columns(&["a", "c"])
-            .build();
+        let mut xf = InteractionFeatures::builder().columns(&["a", "c"]).build();
         xf.fit(df.clone()).unwrap();
         let out = xf.transform(df).unwrap();
 
@@ -489,8 +478,7 @@ mod tests {
     #[test]
     fn test_interaction_explicit_non_f64_column_errors() {
         let a = Column::from(Series::new("a".into(), &[1.0_f64, 2.0, 3.0]));
-        let cat =
-            Column::from(Series::new("cat".into(), &["x", "y", "z"]));
+        let cat = Column::from(Series::new("cat".into(), &["x", "y", "z"]));
         let df = DataFrame::new(3, vec![a, cat]).unwrap();
 
         let mut xf = InteractionFeatures::builder()
@@ -529,9 +517,7 @@ mod tests {
     fn test_interaction_column_order_preserved() {
         // explicit column order [b, a] → pair name b_x_a, not a_x_b
         let df = make_two_col_df();
-        let mut xf = InteractionFeatures::builder()
-            .columns(&["b", "a"])
-            .build();
+        let mut xf = InteractionFeatures::builder().columns(&["b", "a"]).build();
         xf.fit(df.clone()).unwrap();
         let out = xf.transform(df).unwrap();
 

--- a/src/preprocessing/mod.rs
+++ b/src/preprocessing/mod.rs
@@ -9,6 +9,7 @@ pub mod binarizer;
 pub mod encoder;
 pub mod feature_hasher;
 pub mod imputer;
+pub mod interaction_features;
 pub mod missing_indicator;
 pub mod normalizer;
 pub mod polynomial_features;

--- a/src/preprocessing/polynomial_features.rs
+++ b/src/preprocessing/polynomial_features.rs
@@ -5,48 +5,8 @@
 //! `sklearn.preprocessing.PolynomialFeatures`.
 
 use crate::traits::{Error, Fit, Result, Transform};
-use crate::util::require_f64_columns;
+use crate::util::{require_f64_columns, series_mul, series_pow};
 use polars::prelude::*;
-
-fn series_pow(s: &Series, exp: usize) -> Result<Series> {
-    let ca = s.f64().map_err(|e| {
-        Error::Computation(format!(
-            "PolynomialFeatures: expected f64 series for column '{}'. {}",
-            s.name(),
-            e
-        ))
-    })?;
-    let exp_f64 = exp as f64;
-    let result: ChunkedArray<Float64Type> =
-        ca.iter().map(|opt| opt.map(|v| v.powf(exp_f64))).collect();
-    Ok(result.into_series())
-}
-
-fn series_mul(a: &Series, b: &Series) -> Result<Series> {
-    let ca_a = a.f64().map_err(|e| {
-        Error::Computation(format!(
-            "PolynomialFeatures: expected f64 series for column '{}'. {}",
-            a.name(),
-            e
-        ))
-    })?;
-    let ca_b = b.f64().map_err(|e| {
-        Error::Computation(format!(
-            "PolynomialFeatures: expected f64 series for column '{}'. {}",
-            b.name(),
-            e
-        ))
-    })?;
-    let result: ChunkedArray<Float64Type> = ca_a
-        .iter()
-        .zip(ca_b.iter())
-        .map(|(opt_a, opt_b)| match (opt_a, opt_b) {
-            (Some(va), Some(vb)) => Some(va * vb),
-            _ => None,
-        })
-        .collect();
-    Ok(result.into_series())
-}
 
 /// Generate polynomial and interaction features.
 ///
@@ -327,7 +287,7 @@ impl Transform<DataFrame> for PolynomialFeatures {
 
                 if !has_terms {
                     series_vec = Some(if p > 1 {
-                        series_pow(&orig_series, p)?
+                        series_pow(&orig_series, p, "PolynomialFeatures")?
                     } else {
                         orig_series
                     });
@@ -335,7 +295,7 @@ impl Transform<DataFrame> for PolynomialFeatures {
                     has_terms = true;
                 } else {
                     let powered = if p > 1 {
-                        series_pow(&orig_series, p)?
+                        series_pow(&orig_series, p, "PolynomialFeatures")?
                     } else {
                         orig_series
                     };
@@ -345,7 +305,7 @@ impl Transform<DataFrame> for PolynomialFeatures {
                                 .into(),
                         )
                     })?;
-                    series_vec = Some(series_mul(prev, &powered)?);
+                    series_vec = Some(series_mul(prev, &powered, "PolynomialFeatures")?);
                     col_name.push('_');
                     col_name.push_str(name);
                 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@
 //! These utilities exist to keep the per-transformer code free of duplicated
 //! column-discovery, validation, and in-place replacement boilerplate.
 
-use polars::prelude::{ChunkedArray, DataFrame, DataType, Float64Type, IntoSeries};
+use polars::prelude::{ChunkedArray, DataFrame, DataType, Float64Type, IntoSeries, Series};
 
 use crate::traits::{Error, Result};
 
@@ -75,4 +75,51 @@ where
         ))
     })?;
     Ok(())
+}
+
+/// Raise every non-null `f64` element of `s` to the integer power `exp`.
+///
+/// `who` names the calling transformer so failures are easy to trace.
+/// Nulls are preserved; the returned series keeps the input's name.
+pub(crate) fn series_pow(s: &Series, exp: usize, who: &str) -> Result<Series> {
+    let ca = s.f64().map_err(|e| {
+        Error::Computation(format!(
+            "{who}: expected f64 series for column '{}'. {e}",
+            s.name()
+        ))
+    })?;
+    let exp_f64 = exp as f64;
+    let result: ChunkedArray<Float64Type> =
+        ca.iter().map(|opt| opt.map(|v| v.powf(exp_f64))).collect();
+    Ok(result.into_series())
+}
+
+/// Element-wise product of two `f64` series.
+///
+/// `who` names the calling transformer for error context. The returned
+/// series has no name set yet (callers typically rename it). If either
+/// input is null at a given row, the output is null at that row; NaN
+/// values are propagated by the underlying `f64` multiplication.
+pub(crate) fn series_mul(a: &Series, b: &Series, who: &str) -> Result<Series> {
+    let ca_a = a.f64().map_err(|e| {
+        Error::Computation(format!(
+            "{who}: expected f64 series for column '{}'. {e}",
+            a.name()
+        ))
+    })?;
+    let ca_b = b.f64().map_err(|e| {
+        Error::Computation(format!(
+            "{who}: expected f64 series for column '{}'. {e}",
+            b.name()
+        ))
+    })?;
+    let result: ChunkedArray<Float64Type> = ca_a
+        .iter()
+        .zip(ca_b.iter())
+        .map(|(opt_a, opt_b)| match (opt_a, opt_b) {
+            (Some(va), Some(vb)) => Some(va * vb),
+            _ => None,
+        })
+        .collect();
+    Ok(result.into_series())
 }


### PR DESCRIPTION
Closes #68

## Summary

Implements `InteractionFeatures` — a new transformer that generates pairwise interaction features (element-wise products) from `Float64` columns, without pure-power terms or higher-degree crosses.

## Key design decisions

- **Preserve originals**: original columns are kept; interaction columns are appended inline with `DataFrame::with_column` (matching `MissingIndicator` pattern)
- **Builder pattern**: `InteractionFeaturesBuilder` (matching `PolynomialFeaturesBuilder` pattern)
- **Input order**: pairs are generated in the order columns appear (no lexicographic sorting)
- **Separator**: fixed `_x_` (documented potential collisions)
- **Empty input**: rejected in `fit` with `Error::InvalidInput`

## Refactoring

Extracted `series_pow` and `series_mul` from `polynomial_features.rs` into `src/util.rs` as `pub(crate)` helpers with a `who: &str` parameter. `PolynomialFeatures` now delegates to these shared helpers.

## Tests

18 unit tests covering: two/three columns, self-products, null/NaN propagation, not-fitted error, auto-discovery (all-f64, mixed types, no-f64), explicit columns, missing/wrong-type columns, empty DataFrame, zero-value propagation, column order preservation, and Default vs new equivalence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interaction feature generation that appends pairwise products for selected or automatically discovered floating-point columns, with optional self-products (squares). Columns are named from the fitted column order and original data is preserved.
  * Exposed interaction feature types through the public prelude.

* **Bug Fixes**
  * Improved null/NaN propagation and validation for empty or invalid inputs across interaction and polynomial feature calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->