### PR TITLE
chore: bump version to v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-07-12
+
+### Added
+
+- `InteractionFeatures` for generating pairwise interaction features
+  (element-wise products of input column pairs) without the full
+  polynomial expansion. Supports `columns`, `min_degree`, and
+  `max_degree` configuration via `InteractionFeaturesBuilder` (#68).
+
 ### Fixed
 
+- `StandardScaler.fit` now computes variance using the fitted mean
+  regardless of `with_mean`. Previously the variance was computed against
+  `col_mean` (0.0 when `with_mean` is false), producing incorrect scaling
+  when `with_mean = false` (#35).
+- `CyclicalEncoder.fit` now validates input columns and configuration
+  at fit time, surfacing errors early instead of failing during
+  `transform` (#98).
 - `Lagger.fit` now rejects duplicate periods at fit time, returning a clear
   `InvalidInput` error instead of silently overwriting lag columns on
   `transform` (Polars `DataFrame::with_column` replaces same-named columns).
@@ -152,7 +168,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pipeline primitives: `Pipeline`, `ColumnTransformer` with `Remainder`.
 - Comprehensive API docs, module docs, and contributing guide.
 
-[Unreleased]: https://github.com/DeathSurfing/featrs/compare/v0.3.4...HEAD
+[Unreleased]: https://github.com/DeathSurfing/featrs/compare/v0.3.5...HEAD
+[0.3.5]: https://github.com/DeathSurfing/featrs/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/DeathSurfing/featrs/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/DeathSurfing/featrs/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/DeathSurfing/featrs/compare/v0.3.1...v0.3.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "featrs"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 rust-version = "1.91"
 description = "Feature engineering library for Rust, inspired by scikit-learn"


### PR DESCRIPTION
Updates CHANGELOG.md with unreleased changes (InteractionFeatures, CyclicalEncoder validation, StandardScaler variance fix) and bumps version to 0.3.5.\n\nThe v0.3.5 tag has been pushed — the auto-release workflow will trigger on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and handling of invalid or missing values across scalers, encoders, imputers, and transformation tools.
  * Corrected variance calculations in standard scaling.
  * Added earlier validation for cyclical encoding inputs.

* **New Features**
  * Added interaction feature-building functionality.

* **Documentation**
  * Updated release notes for version 0.3.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->