### PR TITLE
fix: align clippy invocation in CI and CONTRIBUTING.md (--all-features)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: cargo build
 
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Format
         run: cargo fmt --check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ cargo test
 ## Code style
 
 - `cargo fmt` before committing
-- `cargo clippy -- -D warnings` must pass
+- `cargo clippy --all-targets --all-features -- -D warnings` must pass
 - 4-space indentation, no trailing whitespace
 - All public items must have doc comments (`///`)
 - Module-level `//!` docs for every `.rs` file


### PR DESCRIPTION
## Summary

Aligns the `cargo clippy` invocation across `.github/workflows/ci.yml:42` and `CONTRIBUTING.md:15` to use the unified command:

```
cargo clippy --all-targets --all-features -- -D warnings
```

## Changes

| File | Before | After |
|------|--------|-------|
| `.github/workflows/ci.yml:42` | `cargo clippy --all-targets -- -D warnings` | `cargo clippy --all-targets --all-features -- -D warnings` |
| `CONTRIBUTING.md:15` | `` `cargo clippy -- -D warnings` `` | `` `cargo clippy --all-targets --all-features -- -D warnings` `` |

## Notes

- **`--all-features`** — no-op today (no `[features]` table in `Cargo.toml`), future-proofs against feature-gated code later.
- **`--all-targets`** — was already in CI but missing from CONTRIBUTING.md; now aligned.
- **`--locked`** — intentionally omitted despite being requested in #18. Verification showed `Cargo.lock` is gitignored (`.gitignore:3`) and uncommitted, so `--locked` would cause CI to fail on a fresh checkout with `error: cannot create the lock file Cargo.lock because --locked was passed to prevent this`. See [issue comment](https://github.com/DeathSurfing/featrs/issues/18#issuecomment-4954812684) for details.

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance to include all targets and features when running Clippy.
* **Chores**
  * Expanded automated code-quality checks to validate all Cargo features and targets, while continuing to treat warnings as errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->