### PR TITLE
fix(PolynomialFeatures): detect bias column name collision at fit time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `PolynomialFeatures.fit` now validates that input columns do not share the
+  `"bias"` name with the synthetic bias column, returning a clear
+  `InvalidInput` error at fit time instead of crashing on duplicate column
+  names during transform (#41).
+
 ## [0.3.5] - 2026-07-12
 
 ### Added

--- a/src/preprocessing/polynomial_features.rs
+++ b/src/preprocessing/polynomial_features.rs
@@ -397,11 +397,13 @@ mod tests {
 
         let mut pf = PolynomialFeatures::new(2).unwrap().include_bias(true);
         let err = pf.fit(df).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("bias") && msg.contains("collides"),
-            "expected error mentioning 'bias' and 'collides', got: {msg}"
-        );
+        match &err {
+            Error::InvalidInput(msg) => {
+                assert!(msg.contains("bias"), "expected message containing 'bias', got: {msg}");
+                assert!(msg.contains("collides"), "expected message containing 'collides', got: {msg}");
+            }
+            other => panic!("expected Error::InvalidInput, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/preprocessing/polynomial_features.rs
+++ b/src/preprocessing/polynomial_features.rs
@@ -228,6 +228,14 @@ impl Fit<DataFrame> for PolynomialFeatures {
             ));
         }
         let col_names = require_f64_columns(&x, "PolynomialFeatures")?;
+        if self.include_bias && col_names.iter().any(|c| c == "bias") {
+            return Err(Error::InvalidInput(
+                "PolynomialFeatures: input contains a column named 'bias', which collides \
+                 with the synthetic bias column. Rename the input column or set \
+                 include_bias(false)."
+                    .into(),
+            ));
+        }
         self.input_columns = Some(col_names);
         self.fitted = true;
         Ok(())
@@ -378,6 +386,33 @@ mod tests {
         pf.fit(df.clone()).unwrap();
         let result = pf.transform(df).unwrap();
 
+        assert_eq!(result.width(), 5);
+    }
+
+    #[test]
+    fn test_bias_column_collision_detected_at_fit() {
+        let bias_col = Column::from(Series::new("bias".into(), &[1.0f64, 2.0, 3.0]));
+        let a = Column::from(Series::new("a".into(), &[4.0f64, 5.0, 6.0]));
+        let df = DataFrame::new(3, vec![bias_col, a]).unwrap();
+
+        let mut pf = PolynomialFeatures::new(2).unwrap().include_bias(true);
+        let err = pf.fit(df).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("bias") && msg.contains("collides"),
+            "expected error mentioning 'bias' and 'collides', got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_bias_column_collision_skipped_when_no_bias() {
+        let bias_col = Column::from(Series::new("bias".into(), &[1.0f64, 2.0, 3.0]));
+        let a = Column::from(Series::new("a".into(), &[4.0f64, 5.0, 6.0]));
+        let df = DataFrame::new(3, vec![bias_col, a]).unwrap();
+
+        let mut pf = PolynomialFeatures::new(2).unwrap().include_bias(false);
+        pf.fit(df.clone()).unwrap();
+        let result = pf.transform(df).unwrap();
         assert_eq!(result.width(), 5);
     }
 

--- a/src/preprocessing/polynomial_features.rs
+++ b/src/preprocessing/polynomial_features.rs
@@ -399,8 +399,14 @@ mod tests {
         let err = pf.fit(df).unwrap_err();
         match &err {
             Error::InvalidInput(msg) => {
-                assert!(msg.contains("bias"), "expected message containing 'bias', got: {msg}");
-                assert!(msg.contains("collides"), "expected message containing 'collides', got: {msg}");
+                assert!(
+                    msg.contains("bias"),
+                    "expected message containing 'bias', got: {msg}"
+                );
+                assert!(
+                    msg.contains("collides"),
+                    "expected message containing 'collides', got: {msg}"
+                );
             }
             other => panic!("expected Error::InvalidInput, got {other:?}"),
         }


### PR DESCRIPTION
Fixes #41

Adds validation in PolynomialFeatures::fit() to detect when an input column is named "bias" and include_bias is true, returning a clear InvalidInput error instead of failing later with a confusing Computation error from duplicate column names.

Also adds two regression tests:
- test_bias_column_collision_detected_at_fit
- test_bias_column_collision_skipped_when_no_bias

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detects input column name collisions with the synthetic `"bias"` feature during fitting when bias generation is enabled.
  * Returns a clear `InvalidInput` validation error (with guidance) instead of crashing or failing later during transformation.
  * Still allows inputs containing a `"bias"` column when bias generation is disabled.
* **Tests**
  * Added coverage for the failing collision case and the successful no-bias case, including expected output width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->