### PR TITLE
fix: reject overlapping column specs in ColumnTransformer.fit()

### DIFF
--- a/src/pipeline/column_transformer.rs
+++ b/src/pipeline/column_transformer.rs
@@ -79,6 +79,21 @@ impl Fit<DataFrame> for ColumnTransformer {
                 "ColumnTransformer.fit received a DataFrame with 0 columns.".into(),
             ));
         }
+
+        let mut seen: HashSet<&str> = HashSet::new();
+        for (t_name, _, columns) in &self.transformers {
+            for c in columns {
+                if !seen.insert(c.as_str()) {
+                    return Err(Error::InvalidInput(format!(
+                        "ColumnTransformer: column '{}' is specified by more than one \
+                         transformer (collision detected on transformer '{}'). Each column \
+                         may belong to at most one transformer.",
+                        c, t_name
+                    )));
+                }
+            }
+        }
+
         for (t_name, transformer, columns) in &mut self.transformers {
             let col_names = columns.clone();
             let subset = x.select(&col_names).map_err(|e| {
@@ -252,5 +267,28 @@ mod tests {
         );
         let df = make_test_df();
         assert!(ct.transform(df).is_err());
+    }
+
+    #[test]
+    fn test_column_transformer_overlapping_columns_errors_at_fit() {
+        let scaler_1 = StandardScaler::new();
+        let scaler_2 = StandardScaler::new();
+        let mut ct = ColumnTransformer::new(
+            vec![
+                ("s1".into(), Box::new(scaler_1), vec!["a".into()]),
+                (
+                    "s2".into(),
+                    Box::new(scaler_2),
+                    vec!["a".into(), "b".into()],
+                ),
+            ],
+            Remainder::Drop,
+        );
+        let df = make_test_df();
+
+        let err = ct.fit(df).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains('a'));
+        assert!(msg.contains("s2"));
     }
 }


### PR DESCRIPTION
## Problem

`ColumnTransformer` doesn't validate that the column specs handed to its transformers are disjoint. If two transformers reference overlapping columns (e.g. `["a"]` and `["a", "b"]`), the same column gets transformed twice and both results get `hstack`ed together — which Polars rejects since duplicate column names aren't allowed. The failure only surfaces at `transform` time as a confusing `hstack` error, rather than being caught at `fit` time where the actual mistake was made.

## Fix

`fit()` now walks the column specs up front and errors with a clear `InvalidInput` if it finds a column claimed by more than one transformer, naming both the column and the transformer that collided:

```
ColumnTransformer: column 'a' is specified by more than one transformer
(collision detected on transformer 's2'). Each column may belong to at
most one transformer.
```

Added a regression test (`test_column_transformer_overlapping_columns_errors_at_fit`) asserting this errors at `fit`, not later at `transform`.

Closes #36

## Testing

- `cargo build --all-features`
- `cargo test --all-features` (106 unit/integration tests + 29 doctests, all passing)
- `cargo clippy --all-features -- -D warnings` (clean)
- `cargo fmt --check` (clean)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Column transformation setup now detects and reports duplicate column assignments across transformers.
  * Error messages identify the conflicting column and transformer, making configuration issues easier to resolve.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->