### PR TITLE
fix: pipeline now tracks its own fitted state, preserves error variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Pipeline` now tracks its own fitted state: `transform` before `fit`
+  returns a clear `NotFitted` error ("Pipeline has not been fitted...")
+  instead of a misleading `Computation` error wrapping an inner step's
+  message. `Pipeline::fit`/`transform` also preserve the original error
+  variant (`InvalidInput`/`NotFitted`) from failing steps instead of
+  collapsing everything into `Computation`. A failed re-fit resets the
+  fitted flag so `transform` cannot silently use stale state (#13).
 - `PolynomialFeatures.fit` now validates that input columns do not share the
   `"bias"` name with the synthetic bias column, returning a clear
   `InvalidInput` error at fit time instead of crashing on duplicate column

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -53,6 +53,7 @@ impl<T> DataFrameTransformer for T where
 /// ```
 pub struct Pipeline {
     steps: Vec<(String, Box<dyn DataFrameTransformer>)>,
+    fitted: bool,
 }
 
 impl Pipeline {
@@ -70,7 +71,10 @@ impl Pipeline {
                     .into(),
             ));
         }
-        Ok(Self { steps })
+        Ok(Self {
+            steps,
+            fitted: false,
+        })
     }
 
     /// Returns a reference to the pipeline steps.
@@ -79,10 +83,23 @@ impl Pipeline {
     }
 }
 
+fn wrap_step_error(e: Error, i: usize, name: &str, phase: &str) -> Error {
+    let msg = format!(
+        "Pipeline: step {} ('{}') failed during {}: {}",
+        i, name, phase, e,
+    );
+    match e {
+        Error::NotFitted(_) => Error::NotFitted(msg),
+        Error::InvalidInput(_) => Error::InvalidInput(msg),
+        Error::Computation(_) => Error::Computation(msg),
+    }
+}
+
 impl Fit<DataFrame> for Pipeline {
     type Output = ();
 
     fn fit(&mut self, x: DataFrame) -> Result<()> {
+        self.fitted = false;
         if x.height() == 0 {
             return Err(Error::InvalidInput(
                 "Pipeline.fit received a DataFrame with 0 rows.".into(),
@@ -92,21 +109,16 @@ impl Fit<DataFrame> for Pipeline {
         let n = self.steps.len();
         for (i, (name, transformer)) in self.steps.iter_mut().enumerate() {
             let is_last = i == n - 1;
-            transformer.fit(x_curr.clone()).map_err(|e| {
-                Error::Computation(format!(
-                    "Pipeline: step {} ('{}') failed during fit: {}",
-                    i, name, e
-                ))
-            })?;
+            transformer
+                .fit(x_curr.clone())
+                .map_err(|e| wrap_step_error(e, i, name, "fit"))?;
             if !is_last {
-                x_curr = transformer.transform(x_curr).map_err(|e| {
-                    Error::Computation(format!(
-                        "Pipeline: step {} ('{}') failed during intermediate transform: {}",
-                        i, name, e
-                    ))
-                })?;
+                x_curr = transformer
+                    .transform(x_curr)
+                    .map_err(|e| wrap_step_error(e, i, name, "intermediate transform"))?;
             }
         }
+        self.fitted = true;
         Ok(())
     }
 }
@@ -115,14 +127,18 @@ impl Transform<DataFrame> for Pipeline {
     type Output = DataFrame;
 
     fn transform(&self, x: DataFrame) -> Result<DataFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted(
+                "Pipeline has not been fitted. \
+                 Call .fit(dataframe) before .transform()."
+                    .into(),
+            ));
+        }
         let mut x_curr = x;
         for (i, (name, transformer)) in self.steps.iter().enumerate() {
-            x_curr = transformer.transform(x_curr).map_err(|e| {
-                Error::Computation(format!(
-                    "Pipeline: step {} ('{}') failed during transform: {}",
-                    i, name, e
-                ))
-            })?;
+            x_curr = transformer
+                .transform(x_curr)
+                .map_err(|e| wrap_step_error(e, i, name, "transform"))?;
         }
         Ok(x_curr)
     }
@@ -182,6 +198,63 @@ mod tests {
         let scaler = StandardScaler::new();
         let pipeline = Pipeline::new(vec![("scaler".into(), Box::new(scaler))]).unwrap();
         let df = make_test_df();
-        assert!(pipeline.transform(df).is_err());
+        let err = pipeline.transform(df).unwrap_err();
+        assert!(
+            matches!(err, Error::NotFitted(_)),
+            "expected NotFitted, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn test_pipeline_fit_preserves_invalid_input() {
+        let scaler = StandardScaler::new();
+        let mut pipeline = Pipeline::new(vec![("scaler".into(), Box::new(scaler))]).unwrap();
+        let int_col = Column::from(Series::new("x".into(), &[1_i64, 2, 3]));
+        let df_no_f64 = DataFrame::new(3, vec![int_col]).unwrap();
+        let err = pipeline.fit(df_no_f64).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidInput(_)),
+            "expected InvalidInput, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn test_pipeline_transform_preserves_invalid_input() {
+        let scaler = StandardScaler::new();
+        let mut pipeline = Pipeline::new(vec![("scaler".into(), Box::new(scaler))]).unwrap();
+        let df = make_test_df();
+        pipeline.fit(df.clone()).unwrap();
+
+        // Transform a dataframe missing column "a", causing an InvalidInput error.
+        let col_b = Column::from(Series::new("b".into(), &[2.0f64, 4.0, 6.0]));
+        let df_missing_a = DataFrame::new(3, vec![col_b]).unwrap();
+        let err = pipeline.transform(df_missing_a).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidInput(_)),
+            "expected InvalidInput, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn test_pipeline_failed_refit_resets_fitted() {
+        let scaler = StandardScaler::new();
+        let mut pipeline = Pipeline::new(vec![("scaler".into(), Box::new(scaler))]).unwrap();
+        let df = make_test_df();
+
+        // First fit succeeds.
+        pipeline.fit(df.clone()).unwrap();
+        assert!(pipeline.transform(df.clone()).is_ok());
+
+        // Second fit on invalid data fails — fitted should be reset.
+        let int_col = Column::from(Series::new("x".into(), &[1_i64, 2, 3]));
+        let df_no_f64 = DataFrame::new(3, vec![int_col]).unwrap();
+        assert!(pipeline.fit(df_no_f64).is_err());
+
+        // Transform should now return NotFitted, not silently use old state.
+        let err = pipeline.transform(df).unwrap_err();
+        assert!(
+            matches!(err, Error::NotFitted(_)),
+            "expected NotFitted after failed refit, got {err:?}",
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #13 — `Pipeline` now tracks its own fitted state so that calling `transform` before `fit` returns a clear `Error::NotFitted` instead of a misleading `Error::Computation` wrapping an inner step's error.

## Changes

### `src/pipeline/mod.rs`
- Added private `fitted: bool` field to `Pipeline` — initialized `false` in `new()`, set `false` at the start of `fit()` (reset on re-fit), set `true` after all steps fit successfully.
- **`transform()`**: early check — if `!self.fitted`, returns `Err(Error::NotFitted("Pipeline has not been fitted..."))`.
- **Error wrapping preserved**: Both `fit()` and `transform()` now wrap inner step errors via a private `wrap_step_error` helper that preserves the original error variant (`NotFitted` stays `NotFitted`, `InvalidInput` stays `InvalidInput`, `Computation` stays `Computation`) instead of collapsing everything into `Error::Computation`.
- **Re-fit safety**: `fitted` is reset at the start of `fit()`, so a failed re-fit leaves the pipeline in a `NotFitted` state rather than silently retaining stale parameters.

### `CHANGELOG.md`
- Added entry under `[Unreleased] -> ### Fixed` documenting the fix (#13).

### Tests added/updated
- `test_pipeline_not_fitted` — asserts `Error::NotFitted` variant, not just `is_err()`.
- `test_pipeline_fit_preserves_invalid_input` — fit on non-f64 data -> asserts `Error::InvalidInput`.
- `test_pipeline_transform_preserves_invalid_input` — transform with missing column after fit -> asserts `Error::InvalidInput`.
- `test_pipeline_failed_refit_resets_fitted` — fit succeeds, refit on invalid data fails, transform -> asserts `Error::NotFitted`.

## Verification
- `cargo test`: 138/138 tests pass (105 unit + 4 integration + 4 time-series + 29 doctests)
- `cargo clippy --all-targets`: no warnings
- `cargo fmt --check`: no formatting changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pipelines now clearly report when transformation is attempted before a successful fit.
  * Preserved specific input and fitting error types instead of reporting generic computation errors.
  * Failed refitting now clears the fitted state, preventing stale results from being used.
* **Tests**
  * Added coverage for fitted-state handling and error preservation.
* **Documentation**
  * Updated the changelog with these fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->