### PR TITLE
fix: track ColumnTransformer fitted state

### DIFF
--- a/src/pipeline/column_transformer.rs
+++ b/src/pipeline/column_transformer.rs
@@ -38,6 +38,7 @@ pub enum Remainder {
 pub struct ColumnTransformer {
     transformers: Vec<(String, Box<dyn DataFrameTransformer>, Vec<String>)>,
     remainder: Remainder,
+    fitted: bool,
 }
 
 impl ColumnTransformer {
@@ -56,6 +57,7 @@ impl ColumnTransformer {
         Self {
             transformers,
             remainder,
+            fitted: false,
         }
     }
 
@@ -74,6 +76,7 @@ impl Fit<DataFrame> for ColumnTransformer {
     type Output = ();
 
     fn fit(&mut self, x: DataFrame) -> Result<()> {
+        self.fitted = false;
         if x.width() == 0 {
             return Err(Error::InvalidInput(
                 "ColumnTransformer.fit received a DataFrame with 0 columns.".into(),
@@ -116,6 +119,7 @@ impl Fit<DataFrame> for ColumnTransformer {
                 ))
             })?;
         }
+        self.fitted = true;
         Ok(())
     }
 }
@@ -124,6 +128,13 @@ impl Transform<DataFrame> for ColumnTransformer {
     type Output = DataFrame;
 
     fn transform(&self, x: DataFrame) -> Result<DataFrame> {
+        if !self.fitted {
+            return Err(Error::NotFitted(
+                "ColumnTransformer has not been fitted. \
+                 Call .fit(dataframe) before .transform()."
+                    .into(),
+            ));
+        }
         let mut parts: Vec<DataFrame> = Vec::new();
 
         for (t_name, transformer, columns) in &self.transformers {
@@ -266,7 +277,34 @@ mod tests {
             Remainder::Passthrough,
         );
         let df = make_test_df();
-        assert!(ct.transform(df).is_err());
+        let err = ct.transform(df).unwrap_err();
+        assert!(
+            matches!(&err, Error::NotFitted(_)),
+            "expected NotFitted, got {err:?}",
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("ColumnTransformer"));
+        assert!(!msg.contains("StandardScaler"));
+    }
+
+    #[test]
+    fn test_column_transformer_failed_refit_resets_fitted() {
+        let scaler = StandardScaler::new();
+        let mut ct = ColumnTransformer::new(
+            vec![("scale_a".into(), Box::new(scaler), vec!["a".into()])],
+            Remainder::Passthrough,
+        );
+        let df = make_test_df();
+
+        ct.fit(df.clone()).unwrap();
+        assert!(ct.transform(df.clone()).is_ok());
+
+        assert!(ct.fit(DataFrame::empty()).is_err());
+        let err = ct.transform(df).unwrap_err();
+        assert!(
+            matches!(err, Error::NotFitted(_)),
+            "expected NotFitted after failed refit, got {err:?}",
+        );
     }
 
     #[test]

--- a/src/pipeline/column_transformer.rs
+++ b/src/pipeline/column_transformer.rs
@@ -282,9 +282,11 @@ mod tests {
             matches!(&err, Error::NotFitted(_)),
             "expected NotFitted, got {err:?}",
         );
-        let msg = err.to_string();
-        assert!(msg.contains("ColumnTransformer"));
-        assert!(!msg.contains("StandardScaler"));
+        assert_eq!(
+            err.to_string(),
+            "not fitted: ColumnTransformer has not been fitted. \
+             Call .fit(dataframe) before .transform()."
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- make `ColumnTransformer` own its fitted state instead of leaking a child transformer error
- reset that state before each fit so a failed refit cannot leave stale fitted behavior
- assert the exact `ColumnTransformer` error and the failed-refit regression

Closes #42

## Validation

- `cargo test` on stable Rust 1.97.1 (149 unit, 8 integration, 32 doctests)
- `rustup run 1.91.0 cargo test` (MSRV; same suite)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps`
- `cargo publish --dry-run --allow-dirty`

I used Codex as a coding assistant and reviewed and tested the resulting patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards to prevent transformations before the column transformer has been successfully fitted.
  * Failed refitting attempts no longer leave the transformer in an incorrectly usable state.
  * Improved error handling for invalid or incomplete transformer setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->