### PR TITLE
docs: add roadmap section pointing at GitHub milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,23 @@ atd.fit(df.clone())?;
 let result = atd.transform(df)?;
 ```
 
+## Roadmap
+
+Work is tracked in [GitHub milestones](https://github.com/DeathSurfing/featrs/milestones). Open issues are grouped by release so contributors can pick a target and see what ships with it.
+
+| Milestone | Focus | Target |
+|---|---|---|
+| [v0.4.0](https://github.com/DeathSurfing/featrs/milestone/1) | New transformers: scalers, encoders, cleaners | Sep 2026 |
+| [v0.5.0](https://github.com/DeathSurfing/featrs/milestone/2) | Text, time-series, feature selection | Oct 2026 |
+| [v0.6.0](https://github.com/DeathSurfing/featrs/milestone/3) | Pipeline composition & automation (FeatureUnion, AutoPipeline, SchemaValidator) | Nov 2026 |
+| [v0.7.0](https://github.com/DeathSurfing/featrs/milestone/4) | Performance workstream (benchmarks, Polars-native kernels, rayon, ahash) + LazyFrame & streaming | Dec 2026 |
+| [v0.8.0](https://github.com/DeathSurfing/featrs/milestone/5) | Quality & docs hardening (lints, doc tests) | Dec 2026 |
+| [v1.0.0](https://github.com/DeathSurfing/featrs/milestone/6) | Persistence (serde), tracing, ONNX export, pipeline versioning | Mar 2027 |
+
+The performance milestones are ordered: benchmarks (Phase 0) land first, then Polars-native kernels, rayon, and ahash. ahash must stabilize before serde persistence ships so the on-disk hash format never changes.
+
+New contributors: start with a `good first issue` in the next milestone.
+
 ## Resources
 
 - [Crates.io](https://crates.io/crates/featrs)


### PR DESCRIPTION
Adds a Roadmap section to the README linking the six new GitHub milestones (v0.4.0 through v1.0.0) that group all 52 open issues by release.

Highlights:
- Milestone table with focus and target month per release
- Notes the perf workstream ordering (benchmarks before kernels, rayon, ahash) and why ahash must land before serde persistence
- Points new contributors at good-first-issues in the next milestone

Docs only, no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Roadmap section outlining upcoming milestones, release targets, planned features, performance priorities, and guidance for new contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->