### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/DeathSurfing/featrs/security/code-scanning/6](https://github.com/DeathSurfing/featrs/security/code-scanning/6)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit minimal required token scope by default.

Best fix here: insert at workflow root (after `on:` and before `env:` is a clean location):

```yaml
permissions:
  contents: read
```

Why this is best:
- It resolves the CodeQL finding for all jobs in one place.
- It preserves existing behavior for CI-style read-only operations.
- It documents intended privilege and protects against broader future defaults.

No imports, methods, or dependencies are needed; this is a YAML-only workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
