### PR TITLE
release: bump version to v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-08-20
+
 ### Added
 
 - `ConstantColumnRemover` for removing columns that contain only a single
@@ -79,6 +81,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `±Inf` is clipped to the bounds, zero-spread and degenerate-overflow
   columns pass through unchanged, and a non-positive multiplier is rejected
   at fit time (#72).
+
+### Fixed
+
+- `ColumnTransformer.transform` now returns a clear `NotFitted` error when
+  called before `fit`, and a failed re-fit resets the fitted state so stale
+  transformer output cannot be used (#42).
 
 ## [0.3.6] - 2026-08-10
 
@@ -276,7 +284,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pipeline primitives: `Pipeline`, `ColumnTransformer` with `Remainder`.
 - Comprehensive API docs, module docs, and contributing guide.
 
-[Unreleased]: https://github.com/featrs/featrs/compare/v0.3.6...HEAD
+[Unreleased]: https://github.com/featrs/featrs/compare/v0.3.7...HEAD
+[0.3.7]: https://github.com/featrs/featrs/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/featrs/featrs/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/featrs/featrs/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/featrs/featrs/compare/v0.3.3...v0.3.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "featrs"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 rust-version = "1.91"
 description = "Feature engineering library for Rust, inspired by scikit-learn"


### PR DESCRIPTION
Bump version to 0.3.7 and finalize the CHANGELOG for the release.

### Changes
- `Cargo.toml`: `0.3.6` → `0.3.7`
- `CHANGELOG.md`: promote the Unreleased section to `[0.3.7] - 2026-08-20` covering the 12 new transformers merged since v0.3.6, add the `ColumnTransformer` fitted-state fix (#42) under Fixed, and update the compare links.

Once merged, tag `v0.3.7` (triggers the GitHub Release) and publish to crates.io.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new transformers and encoders.
* **Bug Fixes**
  * Improved error messages when using `ColumnTransformer` before fitting.
  * Fixed stale fitting state after an unsuccessful refit.
* **Release**
  * Updated the package to version 0.3.7.
  * Added changelog details and comparison links for the release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->