### PR TITLE
Fix Binarizer: preserve NaN as null and reject non-finite thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   named `a_x_b`), or two distinct pairs generate the same name because input
   names contain the `_x_` separator, `transform` returns `Error::InvalidInput`
   naming the conflict — matching the existing `RatioFeatures` behavior (#142).
+- `Binarizer.transform` no longer conflates missing data with a
+  below-threshold value: `NaN` inputs are now emitted as null (matching the
+  polars-null pass-through behavior of sibling transformers) instead of
+  silently becoming `0.0`. Non-finite thresholds (`NaN`, ±`Inf`) are rejected
+  at fit time with `Error::InvalidInput` — previously every value silently
+  binarized to `0.0` under a `NaN` threshold (#141).
 
 ## [0.4.0] - 2026-08-22
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ let scaled = scaler.transform(data)?;
 | | `OutlierClipper` | Clip outliers via IQR, Z-score, or MAD statistical fences |
 | | `KBinsDiscretizer` | Bin continuous features into `n_bins` discrete bins (uniform, quantile, or k-means) as ordinal or one-hot |
 | **Normalization** | `Normalizer` | Row-wise L1, L2, or Max normalization |
-| | `Binarizer` | Threshold-based binarization |
+| | `Binarizer` | Threshold-based binarization; in Float64 columns, nulls and NaN pass through as null |
 | **Encoding** | `OneHotEncoder` | Create binary dummy columns for categories |
 | | `LabelEncoder` | Encode labels as `0..n_classes-1` integers |
 | | `OrdinalEncoder` | Per-column category → integer encoding |

--- a/src/preprocessing/binarizer.rs
+++ b/src/preprocessing/binarizer.rs
@@ -1,15 +1,24 @@
 //! Feature binarization.
 //!
 //! [`Binarizer`] thresholds numeric features: values above the threshold
-//! become `1.0`, others become `0.0`.
+//! become `1.0`, others become `0.0`. Missing data is preserved: polars
+//! nulls stay null, and non-finite `NaN` inputs are emitted as null rather
+//! than being conflated with a below-threshold value.
 
 use crate::traits::{Error, Fit, Result, Transform};
-use crate::util::replace_f64_column;
+use crate::util::{numeric_f64_columns, replace_f64_column_opt};
 use polars::prelude::*;
 
 /// Binarize data according to a threshold.
 ///
-/// Values `> threshold` become `1.0`; all others become `0.0`.
+/// Values `> threshold` become `1.0`; all other finite values become `0.0`.
+/// Missing data is preserved through transform: nulls stay null, and `NaN`
+/// inputs are emitted as null so downstream models can distinguish missing
+/// values from below-threshold ones. ±`Inf` inputs binarize normally against
+/// the finite threshold.
+///
+/// The threshold must be finite (`NaN` or ±`Inf` thresholds are rejected at
+/// fit time).
 ///
 /// # Example
 ///
@@ -35,7 +44,10 @@ pub struct Binarizer {
 impl Binarizer {
     /// Create a new `Binarizer` with the given threshold.
     ///
-    /// Values strictly greater than `threshold` are set to `1.0`.
+    /// Values strictly greater than `threshold` are set to `1.0`. The
+    /// threshold is validated when [`Fit::fit`] is called; builders return
+    /// `Self` and cannot signal errors, so an invalid threshold surfaces as
+    /// an `Error::InvalidInput` from `fit`.
     pub fn new(threshold: f64) -> Self {
         Self {
             fitted: false,
@@ -54,9 +66,20 @@ impl Default for Binarizer {
 impl Fit<DataFrame> for Binarizer {
     type Output = ();
 
-    /// Fit the binarizer by validating the input DataFrame has
-    /// at least one row and one column.
+    /// Validate the input DataFrame has at least one row and one column,
+    /// and that the configured threshold is finite.
     fn fit(&mut self, x: DataFrame) -> Result<()> {
+        // Reset fitted state up front: if this fit fails, transform must
+        // not silently apply a stale configuration from a previous fit.
+        self.fitted = false;
+
+        if !self.threshold.is_finite() {
+            return Err(Error::InvalidInput(format!(
+                "Binarizer.fit received a non-finite threshold ({}). \
+                 Provide a finite threshold.",
+                self.threshold
+            )));
+        }
         if x.height() == 0 || x.width() == 0 {
             return Err(Error::InvalidInput(
                 "Binarizer.fit received an empty DataFrame (0 rows or 0 columns). \
@@ -73,7 +96,8 @@ impl Transform<DataFrame> for Binarizer {
     type Output = DataFrame;
 
     /// Binarize the data: values above the threshold become `1.0`,
-    /// others become `0.0`.
+    /// other finite values become `0.0`, and missing data stays missing —
+    /// nulls remain null and `NaN` inputs are emitted as null.
     fn transform(&self, x: DataFrame) -> Result<DataFrame> {
         if !self.fitted {
             return Err(Error::NotFitted(
@@ -83,25 +107,20 @@ impl Transform<DataFrame> for Binarizer {
             ));
         }
 
-        let col_names: Vec<String> = x
-            .get_column_names()
-            .iter()
-            .filter_map(|name| {
-                let col = x.column(name).ok()?;
-                if col.dtype() == &DataType::Float64 {
-                    Some(name.to_string())
-                } else {
-                    None
-                }
-            })
-            .collect();
+        let col_names = numeric_f64_columns(&x);
 
         let mut out = x.clone();
         let threshold = self.threshold;
 
         for name in &col_names {
-            replace_f64_column(&mut out, name.as_str(), "Binarizer", |v| {
-                if v > threshold { 1.0 } else { 0.0 }
+            replace_f64_column_opt(&mut out, name.as_str(), "Binarizer", |v| {
+                if v.is_nan() {
+                    None
+                } else if v > threshold {
+                    Some(1.0)
+                } else {
+                    Some(0.0)
+                }
             })?;
         }
 
@@ -113,6 +132,11 @@ impl Transform<DataFrame> for Binarizer {
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
+    use polars::prelude::AnyValue;
+
+    fn column_values(col: &Column) -> Vec<Option<f64>> {
+        col.f64().unwrap().iter().collect()
+    }
 
     #[test]
     fn test_binarizer_default() {
@@ -174,5 +198,135 @@ mod tests {
             err.to_string().contains("empty DataFrame"),
             "error message should mention the empty DataFrame"
         );
+    }
+
+    #[test]
+    fn test_binarizer_preserves_null_and_nan() {
+        let mut b = Binarizer::new(0.5);
+        // Rows: 0 -> 2.0 (above), 1 -> null, 2 -> NaN, 3 -> -1.0 (below).
+        let a = Column::from(Series::new(
+            "x".into(),
+            &[Some(2.0), None, Some(f64::NAN), Some(-1.0)],
+        ));
+        let df = DataFrame::new(4, vec![a]).unwrap();
+
+        b.fit(df.clone()).unwrap();
+        let result = b.transform(df).unwrap();
+
+        let vals = column_values(result.column("x").unwrap());
+        assert_relative_eq!(vals[0].unwrap(), 1.0, epsilon = 1e-6);
+        assert!(vals[1].is_none(), "null input must stay null");
+        assert!(
+            vals[2].is_none(),
+            "NaN input must be emitted as null, not 0.0"
+        );
+        assert_relative_eq!(vals[3].unwrap(), 0.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_binarizer_rejects_nan_threshold() {
+        let a = Column::from(Series::new("x".into(), &[1.0f64, 2.0]));
+        let df = DataFrame::new(2, vec![a]).unwrap();
+
+        let mut b = Binarizer::new(f64::NAN);
+        let err = b.fit(df).unwrap_err();
+        assert!(
+            err.to_string().contains("non-finite threshold"),
+            "error message should mention the non-finite threshold"
+        );
+        assert!(
+            !b.fitted,
+            "a failed fit must not mark the transformer fitted"
+        );
+    }
+
+    #[test]
+    fn test_binarizer_rejects_infinite_threshold() {
+        let a = Column::from(Series::new("x".into(), &[1.0f64, 2.0]));
+        let df = DataFrame::new(2, vec![a]).unwrap();
+
+        for threshold in [f64::INFINITY, f64::NEG_INFINITY] {
+            let mut b = Binarizer::new(threshold);
+            let err = b.fit(df.clone()).unwrap_err();
+            assert!(
+                err.to_string().contains("non-finite threshold"),
+                "error message should mention the non-finite threshold"
+            );
+        }
+    }
+
+    #[test]
+    fn test_binarizer_not_fitted() {
+        let b = Binarizer::new(0.5);
+        let result = b.transform(DataFrame::default());
+        assert!(
+            matches!(result, Err(Error::NotFitted(_))),
+            "transform before fit must return NotFitted"
+        );
+    }
+
+    #[test]
+    fn test_binarizer_refit_resets_fitted_state() {
+        let good = Column::from(Series::new("x".into(), &[1.0f64, 2.0]));
+        let good_df = DataFrame::new(2, vec![good]).unwrap();
+
+        let mut b = Binarizer::new(0.5);
+        b.fit(good_df.clone()).unwrap();
+        assert!(b.fitted);
+
+        // A re-fit that fails validation must leave the transformer unfitted
+        // rather than silently keeping stale state.
+        let bad_df = DataFrame::new(0, Vec::<Column>::new()).unwrap();
+        assert!(b.fit(bad_df).is_err());
+        assert!(!b.fitted, "a failed re-fit must reset the fitted flag");
+
+        b.fit(good_df).unwrap();
+        assert!(b.fitted);
+    }
+
+    #[test]
+    fn test_binarizer_non_f64_columns_pass_through() {
+        let mut b = Binarizer::new(0.5);
+        let x = Column::from(Series::new("x".into(), &[-1.0f64, 0.9]));
+        let s = Column::from(Series::new("s".into(), &["a".to_string(), "b".to_string()]));
+        let df = DataFrame::new(2, vec![x, s]).unwrap();
+
+        b.fit(df.clone()).unwrap();
+        let result = b.transform(df).unwrap();
+
+        let vals: Vec<f64> = result
+            .column("x")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .iter()
+            .flatten()
+            .collect();
+        assert_relative_eq!(vals[0], 0.0, epsilon = 1e-6);
+        assert_relative_eq!(vals[1], 1.0, epsilon = 1e-6);
+        match result.column("s").unwrap().get(0).unwrap() {
+            AnyValue::String(v) => assert_eq!(v, "a"),
+            other => panic!("expected string value, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_binarizer_infinite_inputs_keep_comparison_semantics() {
+        // ±Inf inputs compare meaningfully against a finite threshold and are
+        // binarized like any other finite-or-infinite value; only NaN is
+        // treated as missing data.
+        let mut b = Binarizer::new(0.5);
+        let a = Column::from(Series::new(
+            "x".into(),
+            &[Some(f64::INFINITY), Some(f64::NEG_INFINITY)],
+        ));
+        let df = DataFrame::new(2, vec![a]).unwrap();
+
+        b.fit(df.clone()).unwrap();
+        let result = b.transform(df).unwrap();
+
+        let vals = column_values(result.column("x").unwrap());
+        assert_relative_eq!(vals[0].unwrap(), 1.0, epsilon = 1e-6);
+        assert_relative_eq!(vals[1].unwrap(), 0.0, epsilon = 1e-6);
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -59,6 +59,20 @@ pub fn replace_f64_column<F>(df: &mut DataFrame, name: &str, who: &str, f: F) ->
 where
     F: Fn(f64) -> f64,
 {
+    replace_f64_column_opt(df, name, who, move |v| Some(f(v)))
+}
+
+/// Apply a per-element optional f64 transform to a single named column of `df`,
+/// replacing the column in place.
+///
+/// Unlike [`replace_f64_column`], `f` may return `None` to emit a null,
+/// letting callers map sentinel values such as `NaN` to missing data instead
+/// of a computed value. Input nulls never reach `f` and stay null.
+/// `who` names the calling transformer for error context.
+pub fn replace_f64_column_opt<F>(df: &mut DataFrame, name: &str, who: &str, f: F) -> Result<()>
+where
+    F: Fn(f64) -> Option<f64>,
+{
     let s = df.column(name).map_err(|e| {
         Error::InvalidInput(format!("{who}.transform: column '{name}' not found. {e}"))
     })?;
@@ -68,7 +82,7 @@ where
             s.dtype()
         ))
     })?;
-    let mapped: ChunkedArray<Float64Type> = ca.iter().map(|opt| opt.map(&f)).collect();
+    let mapped: ChunkedArray<Float64Type> = ca.iter().map(|opt| opt.and_then(&f)).collect();
     df.replace(name, mapped.into_series().into()).map_err(|e| {
         Error::Computation(format!(
             "{who}.transform: failed to replace column '{name}'. {e}"
@@ -167,4 +181,50 @@ pub(crate) fn series_div(a: &Series, b: &Series, epsilon: f64, who: &str) -> Res
         })
         .collect();
     Ok(result.into_series())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use polars::prelude::{Column, NamedFrom};
+
+    #[test]
+    fn test_replace_f64_column_opt_maps_none_to_null() {
+        let x = Column::from(Series::new(
+            "x".into(),
+            &[Some(1.0), Some(f64::NAN), Some(-3.0)],
+        ));
+        let mut df = DataFrame::new(3, vec![x]).unwrap();
+
+        replace_f64_column_opt(&mut df, "x", "Test", |v| {
+            if v.is_nan() { None } else { Some(v) }
+        })
+        .unwrap();
+
+        let vals: Vec<Option<f64>> = df.column("x").unwrap().f64().unwrap().iter().collect();
+        assert_eq!(vals[0], Some(1.0));
+        assert!(vals[1].is_none(), "None from the closure must become null");
+        assert_eq!(vals[2], Some(-3.0));
+    }
+
+    #[test]
+    fn test_replace_f64_column_opt_missing_column_errors() {
+        let mut df = DataFrame::new(0, Vec::<Column>::new()).unwrap();
+        let err = replace_f64_column_opt(&mut df, "nope", "Test", Some).unwrap_err();
+        assert!(
+            err.to_string().contains("not found"),
+            "error should name the missing column"
+        );
+    }
+
+    #[test]
+    fn test_replace_f64_column_opt_wrong_dtype_errors() {
+        let s = Column::from(Series::new("s".into(), &["a".to_string(), "b".to_string()]));
+        let mut df = DataFrame::new(2, vec![s]).unwrap();
+        let err = replace_f64_column_opt(&mut df, "s", "Test", Some).unwrap_err();
+        assert!(
+            err.to_string().contains("expected Float64"),
+            "error should mention the dtype requirement"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes two silent-corruption paths in `Binarizer` (#141):

1. **NaN inputs became 0.0.** `v > threshold` is false for NaN, so missing data was indistinguishable from a confident below-threshold signal. NaN is now emitted as **null** (polars nulls already stayed null), matching the crate-wide null-preservation convention stated in lib.rs.
2. **Non-finite thresholds were accepted silently.** A `NaN` threshold makes every comparison false (all-zero output); ±`Inf` thresholds make the output constant. Builders return `Self` and cannot error, so — following the Winsorizer fit-time validation precedent — `fit` now rejects them with `Error::InvalidInput("non-finite threshold ...")`.

Also adopts the crate convention that a failed re-fit must not leave stale fitted state: `fitted` is reset at the top of `fit` (same pattern as `ConstantColumnRemover`, `OutlierClipper`, etc.).

## Behavior

| Input | Before | After |
|---|---|---|
| finite `> threshold` | 1.0 | 1.0 |
| finite `<= threshold` | 0.0 | 0.0 |
| polars null | null | null (unchanged) |
| `NaN` | 0.0 ❌ | **null** |
| `±Inf` input | binarized by comparison | binarized by comparison (unchanged, documented) |
| `NaN`/`±Inf` threshold | accepted, garbage output ❌ | `Error::InvalidInput` at fit |

Non-`Float64` columns pass through untouched, as before.

## Implementation notes

- New `util::replace_f64_column_opt`: variant of `replace_f64_column` whose closure returns `Option<f64>` so callers can emit nulls; `replace_f64_column` now delegates to it rather than duplicating the column-lookup/dtype-check/replace boilerplate.
- Column discovery in `transform` switched to the existing `util::numeric_f64_columns` helper.

## Test plan

- 10 unit tests: happy path, custom threshold, null+NaN preservation, NaN/±Inf threshold rejection (incl. fitted-flag reset on failed re-fit), NotFitted, non-f64 pass-through, ±Inf-input semantics, empty-frame rejection
- 3 new util tests covering `replace_f64_column_opt` None→null mapping and both error branches directly
- `cargo fmt` clean, `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo test --lib` targeted suites pass (binarizer/util/log_transformer/scaler/quantile/outlier_clipper — all consumers of the refactored helper), doctest passes

Closes #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `Binarizer.transform` now preserves null values and converts `NaN` inputs to null.
  - `Binarizer.fit` rejects non-finite thresholds with an invalid-input error.
  - Infinite input values continue to be handled correctly.
  - Re-fitting after invalid configuration now resets the fitted state appropriately.

- **Documentation**
  - Updated the changelog and README to describe null and `NaN` handling for `Float64` columns.
  - Expanded coverage for missing values, invalid thresholds, infinite inputs, and unsupported data types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->