### PR TITLE
chore: finalize 0.4.0 changelog for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-08-25
 
 ### Added
 
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `RollingAggregator` no longer compacts nulls out of fixed-size windows:
+  input nulls keep their row positions and a window containing a missing
+  value produces a missing result, so output length always matches input
+  length. Null-free aggregation behavior is unchanged (#146).
 - `FClassif` now uses centered accumulation for ANOVA means and sums of
   squares, so decimal-valued constant features score `0.0`, decimal-valued
   perfect separators score positive infinity, and small real variance remains


### PR DESCRIPTION
Release prep for v0.4.0.

- Folds the `[Unreleased]` CHANGELOG entries into a dated `[0.4.0] - 2026-08-25` section
- Adds the rolling-window null-alignment fix (#146, merged in #153) that landed after the version bump but was missing from the changelog

After merge, tag `v0.4.0` on main; the existing release workflow extracts this section as the release notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rolling aggregation for fixed-size windows to preserve null positions and output length.
  * Windows containing missing input now correctly return null.

* **Documentation**
  * Published version 0.4.0 with a release date of August 25, 2026.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->