### PR TITLE
Fix CyclicalEncoder zero-period silently emitting NaN/Inf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `CyclicalEncoder.fit` now rejects periods below 1 with
+  `Error::InvalidInput` instead of silently emitting `NaN`/`±Inf`
+  sin/cos encodings (`two_pi * v / 0.0`). Period `1` remains valid,
+  and fit no longer leaves stale fitted state after a failed re-fit (#149).
 - `LeaveOneOutEncoder.transform` no longer silently returns full-sample target
   means when the transform frame is not the exact training frame (a row subset,
   new rows, or a different column set), which leaked each row's own target into

--- a/src/time_series/cyclical.rs
+++ b/src/time_series/cyclical.rs
@@ -12,6 +12,11 @@ use polars::prelude::*;
 /// For each column, computes `sin(2π * x / period)` and
 /// `cos(2π * x / period)`, preserving the cyclic relationship.
 ///
+/// Periods are validated at [`fit`](Fit::fit) time: every period must be
+/// finite and `>= 1`; otherwise `fit` returns [`Error::InvalidInput`] whose
+/// message contains `period must be >= 1`. A zero (or non-positive) period
+/// would divide by zero and silently emit `NaN`/`±Inf` encodings.
+///
 /// # Example
 ///
 /// ```rust
@@ -61,6 +66,7 @@ impl Fit<DataFrame> for CyclicalEncoder {
     type Output = ();
 
     fn fit(&mut self, x: DataFrame) -> Result<()> {
+        self.fitted = false;
         let n_cols = x.width();
         if x.height() == 0 || n_cols == 0 {
             return Err(Error::InvalidInput(
@@ -86,6 +92,13 @@ impl Fit<DataFrame> for CyclicalEncoder {
                     "CyclicalEncoder: column '{}' has dtype {}; expected Float64.",
                     col,
                     s.dtype()
+                )));
+            }
+        }
+        for (col, period) in &self.columns {
+            if !period.is_finite() || *period < 1.0 {
+                return Err(Error::InvalidInput(format!(
+                    "CyclicalEncoder: period must be >= 1 (got {period} for column '{col}')."
                 )));
             }
         }
@@ -222,5 +235,80 @@ mod tests {
             "Expected Error::InvalidInput containing 'at least one column is required', got: {:?}",
             err
         );
+    }
+
+    #[test]
+    fn test_zero_period_rejected_new() {
+        let vals = Column::from(Series::new("hour".into(), &[0.0_f64, 6.0]));
+        let df = DataFrame::new(2, vec![vals]).unwrap();
+        let mut enc = CyclicalEncoder::new(&["hour"], 0);
+        let err = enc.fit(df).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidInput(ref msg) if msg.contains("period must be >= 1")),
+            "Expected Error::InvalidInput containing 'period must be >= 1', got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_zero_period_rejected_with_periods() {
+        let vals = Column::from(Series::new("hour".into(), &[0.0_f64, 6.0]));
+        let df = DataFrame::new(2, vec![vals]).unwrap();
+        let mut enc = CyclicalEncoder::with_periods(&[("hour", 0)]);
+        let err = enc.fit(df).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidInput(ref msg) if msg.contains("period must be >= 1")),
+            "Expected Error::InvalidInput containing 'period must be >= 1', got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_period_one_boundary() {
+        // period = 1 is the smallest valid period: integer values land at
+        // multiples of 2π, so sin ≈ 0 and cos ≈ 1.
+        let vals = Column::from(Series::new("hour".into(), &[0.0_f64, 1.0, 3.0]));
+        let df = DataFrame::new(3, vec![vals]).unwrap();
+        let mut enc = CyclicalEncoder::new(&["hour"], 1);
+
+        enc.fit(df.clone()).unwrap();
+        let result = enc.transform(df).unwrap();
+
+        assert_eq!(result.width(), 3); // hour, hour_sin, hour_cos
+        let sin = result.column("hour_sin").unwrap().f64().unwrap();
+        let cos = result.column("hour_cos").unwrap().f64().unwrap();
+
+        for i in 0..3 {
+            let s = sin.get(i).unwrap();
+            let c = cos.get(i).unwrap();
+            assert!(
+                s.is_finite() && c.is_finite(),
+                "period=1 outputs must be finite, got sin={s}, cos={c}"
+            );
+            assert_relative_eq!(s, 0.0, epsilon = 1e-6);
+            assert_relative_eq!(c, 1.0, epsilon = 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_failed_refit_resets_fitted_state() {
+        // A successful fit followed by a failed re-fit (zero period) must
+        // leave the encoder un-fitted: transform must return NotFitted.
+        let vals = Column::from(Series::new("hour".into(), &[0.0_f64, 6.0]));
+        let df = DataFrame::new(2, vec![vals]).unwrap();
+        let mut enc = CyclicalEncoder::new(&["hour"], 24);
+
+        enc.fit(df.clone()).unwrap();
+        assert!(enc.transform(df.clone()).is_ok());
+
+        let bad = CyclicalEncoder::new(&["hour"], 0);
+        enc.columns = bad.columns;
+        let err = enc.fit(df.clone()).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidInput(ref msg) if msg.contains("period must be >= 1")),
+            "Expected Error::InvalidInput containing 'period must be >= 1', got: {:?}",
+            err
+        );
+        assert!(matches!(enc.transform(df), Err(Error::NotFitted(_))));
     }
 }

--- a/src/time_series/cyclical.rs
+++ b/src/time_series/cyclical.rs
@@ -13,9 +13,9 @@ use polars::prelude::*;
 /// `cos(2π * x / period)`, preserving the cyclic relationship.
 ///
 /// Periods are validated at [`fit`](Fit::fit) time: every period must be
-/// finite and `>= 1`; otherwise `fit` returns [`Error::InvalidInput`] whose
-/// message contains `period must be >= 1`. A zero (or non-positive) period
-/// would divide by zero and silently emit `NaN`/`±Inf` encodings.
+/// `>= 1`; otherwise `fit` returns [`Error::InvalidInput`] whose message
+/// contains `period must be >= 1`. A zero period would divide by zero and
+/// silently emit `NaN`/`±Inf` encodings.
 ///
 /// # Example
 ///
@@ -41,6 +41,8 @@ pub struct CyclicalEncoder {
 impl CyclicalEncoder {
     /// Create an encoder that maps each column to `(sin, cos)` using a single
     /// shared integer period (e.g. `24` for hours, `12` for months).
+    ///
+    /// Periods below 1 are rejected at `fit` time with [`Error::InvalidInput`].
     pub fn new(columns: &[&str], period: usize) -> Self {
         let period_f = period as f64;
         Self {
@@ -96,7 +98,7 @@ impl Fit<DataFrame> for CyclicalEncoder {
             }
         }
         for (col, period) in &self.columns {
-            if !period.is_finite() || *period < 1.0 {
+            if *period < 1.0 {
                 return Err(Error::InvalidInput(format!(
                     "CyclicalEncoder: period must be >= 1 (got {period} for column '{col}')."
                 )));


### PR DESCRIPTION
## Summary
- `CyclicalEncoder::new` / `::with_periods` cast the period `usize` to `f64` without validation; with `period = 0`, transform computed `two_pi * v / 0.0` and silently emitted `NaN`/`±Inf` sin/cos columns. Fit validated column existence and dtype but never the period itself.
- `fit` now validates that every stored period is `>= 1`, returning `Error::InvalidInput` whose message contains `period must be >= 1` (with the offending column name). This mirrors the Winsorizer fit-time-validation precedent: the constructors return `Self` and cannot signal errors, so builder-config validity is enforced at fit. Periods only enter as `usize`, so every stored value is finite by construction and no separate finiteness check is needed.
- `fit` resets `self.fitted = false` at the top so a failed re-fit cannot leave stale fitted state behind; `transform` then correctly reports `NotFitted`.
- Documented the period contract on the struct docs.

Closes #149

## Test plan
- [x] TDD: zero-period rejection tests watched failing (fit returned Ok) before the fix was added; all green after
- [x] `cargo test --lib cyclical` — 6/6 pass: zero-period rejection via both constructors, period = 1 boundary finiteness (`sin ≈ 0, cos ≈ 1`), failed re-fit resets fitted state, plus existing regression tests unchanged
- [x] `cargo test --doc cyclical` — doctest passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `rustfmt --edition 2024 --check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cyclical encoding now rejects periods below 1, including zero.
  - Period 1 remains supported as a valid boundary case.
  - Failed attempts to reconfigure an encoder no longer leave stale fitted state behind.

- **Documentation**
  - Added clearer guidance on valid period values during setup.

- **Tests**
  - Expanded coverage for periods below 1, boundary behavior, and failed reconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->