### PR TITLE
Reject colliding OneHotEncoder {col}_{category} output names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `OneHotEncoder.fit` now rejects generated output names that collide with an
+  existing input column or another generated one-hot column (e.g. column `a`
+  with category `b_c` and column `a_b` with category `c` both producing
+  `a_b_c`), returning `Error::InvalidInput` instead of silently overwriting
+  or mis-naming columns (#138).
 - `CyclicalEncoder.fit` now rejects periods below 1 with
   `Error::InvalidInput` instead of silently emitting `NaN`/`±Inf`
   sin/cos encodings (`two_pi * v / 0.0`). Period `1` remains valid,

--- a/src/preprocessing/encoder.rs
+++ b/src/preprocessing/encoder.rs
@@ -120,6 +120,10 @@ impl Fit<DataFrame> for OneHotEncoder {
     type Output = ();
 
     fn fit(&mut self, x: DataFrame) -> Result<()> {
+        // Reset state first so a failed fit (including the collision guard
+        // below) cannot leave a stale output plan usable by a later transform.
+        self.fitted = false;
+        self.categories = None;
         if x.height() == 0 {
             return Err(Error::InvalidInput(
                 "OneHotEncoder.fit received a DataFrame with 0 rows. \
@@ -1184,6 +1188,34 @@ mod tests {
         let result = enc.transform(df).unwrap();
         // "a" emits "a_c"; "a_b" emits "a_b_w".
         assert_eq!(result.width(), 2);
+    }
+
+    #[test]
+    fn test_one_hot_failed_refit_clears_state() {
+        // Fit successfully, then re-fit on colliding data. The failed re-fit
+        // must clear the plan so a later transform returns NotFitted rather
+        // than reusing the stale output plan.
+        let ok =
+            DataFrame::new(2, vec![Column::from(Series::new("a".into(), &["b", "x"]))]).unwrap();
+        let mut enc = OneHotEncoder::new();
+        enc.fit(ok.clone()).unwrap();
+
+        let bad = DataFrame::new(
+            2,
+            vec![
+                Column::from(Series::new("a".into(), &["b_c", "x"])),
+                Column::from(Series::new("a_b".into(), &["c", "y"])),
+            ],
+        )
+        .unwrap();
+        let err = enc.fit(bad).unwrap_err();
+        assert!(matches!(err, Error::InvalidInput(_)));
+
+        let err2 = enc.transform(ok).unwrap_err();
+        assert!(
+            matches!(err2, Error::NotFitted(_)),
+            "failed re-fit must clear the output plan"
+        );
     }
 
     #[test]

--- a/src/preprocessing/encoder.rs
+++ b/src/preprocessing/encoder.rs
@@ -10,7 +10,7 @@
 
 use crate::traits::{Error, Fit, Result, Transform};
 use polars::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 fn column_unique_strings(col: &Column) -> Result<Vec<String>> {
     let s = col.as_materialized_series();
@@ -37,7 +37,9 @@ fn column_unique_strings(col: &Column) -> Result<Vec<String>> {
 /// Encode categorical features as a one-hot numeric array.
 ///
 /// Creates a binary column for each category value. Non-string columns
-/// are ignored.
+/// are ignored. Output columns are named `{col}_{category}`; a generated
+/// name that collides with an input column or another generated column is
+/// rejected at fit with [`Error::InvalidInput`].
 ///
 /// # Example
 ///
@@ -64,6 +66,24 @@ pub struct OneHotEncoder {
 struct OneHotCategory {
     column: String,
     categories: Vec<String>,
+}
+
+/// The planned `(column, category)` one-hot pairs, in output order, honoring
+/// `drop_first`.
+///
+/// This is the single source of truth for what `transform` emits: both the
+/// fit-time name-collision guard and the transform loop derive their planned
+/// columns from it, so they can never drift apart.
+fn planned_pairs(cats: &[OneHotCategory], drop_first: bool) -> Vec<(String, String)> {
+    let start = if drop_first { 1 } else { 0 };
+    cats.iter()
+        .flat_map(|cat| {
+            cat.categories
+                .iter()
+                .skip(start)
+                .map(move |category| (cat.column.clone(), category.clone()))
+        })
+        .collect()
 }
 
 impl OneHotEncoder {
@@ -130,6 +150,26 @@ impl Fit<DataFrame> for OneHotEncoder {
             ));
         }
 
+        // Reject name collisions up front: `transform` emits `{col}_{category}`
+        // for every fitted category, and a generated name equal to an input
+        // column (or another generated name) would silently overwrite data.
+        // Mirror the plan `transform` will produce so the two can never drift.
+        let mut seen: HashSet<String> = x
+            .get_column_names()
+            .iter()
+            .map(|n| n.as_str().to_string())
+            .collect();
+        for (col, category) in planned_pairs(&cats, self.drop_first) {
+            let out_name = format!("{col}_{category}");
+            if !seen.insert(out_name.clone()) {
+                return Err(Error::InvalidInput(format!(
+                    "OneHotEncoder: generated column '{out_name}' collides with an \
+                     existing input column or another generated column. Rename the \
+                     conflicting input column."
+                )));
+            }
+        }
+
         self.categories = Some(cats);
         self.fitted = true;
         Ok(())
@@ -157,12 +197,12 @@ impl Transform<DataFrame> for OneHotEncoder {
         let mut new_cols: Vec<Column> = Vec::new();
         let n_rows = x.height();
 
-        for cat in cats {
-            let s = x.column(&cat.column).map_err(|e| {
+        for (col, category) in &planned_pairs(cats, self.drop_first) {
+            let s = x.column(col).map_err(|e| {
                 Error::InvalidInput(format!(
                     "OneHotEncoder.transform: column '{}' not found in input. \
                      The encoder was fitted on columns: {:?}. {}",
-                    cat.column,
+                    col,
                     cats.iter().map(|c| &c.column).collect::<Vec<_>>(),
                     e
                 ))
@@ -170,25 +210,22 @@ impl Transform<DataFrame> for OneHotEncoder {
             let ca = s.as_materialized_series().str().map_err(|e| {
                 Error::InvalidInput(format!(
                     "OneHotEncoder.transform: column '{}' has dtype {}; expected String. {}",
-                    cat.column,
+                    col,
                     s.dtype(),
                     e
                 ))
             })?;
-            let start_idx = if self.drop_first { 1 } else { 0 };
 
-            for (_j, category) in cat.categories.iter().enumerate().skip(start_idx) {
-                let mut vals = vec![0.0f64; n_rows];
-                for (i, opt) in ca.iter().enumerate() {
-                    if let Some(v) = opt
-                        && v == *category
-                    {
-                        vals[i] = 1.0;
-                    }
+            let mut vals = vec![0.0f64; n_rows];
+            for (i, opt) in ca.iter().enumerate() {
+                if let Some(v) = opt
+                    && v == *category
+                {
+                    vals[i] = 1.0;
                 }
-                let col_name = format!("{}_{}", cat.column, category);
-                new_cols.push(Column::from(Series::new(col_name.as_str().into(), &vals)));
             }
+            let col_name = format!("{col}_{category}");
+            new_cols.push(Column::from(Series::new(col_name.as_str().into(), &vals)));
         }
 
         DataFrame::new(n_rows, new_cols).map_err(|e| Error::Computation(e.to_string()))
@@ -1100,6 +1137,53 @@ mod tests {
         let result = enc.transform(df).unwrap();
 
         assert_eq!(result.width(), 4);
+    }
+
+    #[test]
+    fn test_one_hot_name_collision_errors() {
+        // Column "a" (category "b_c") and column "a_b" (category "c") both
+        // generate the output name "a_b_c"; fit must reject the ambiguity.
+        let a = Column::from(Series::new("a".into(), &["b_c", "x"]));
+        let a_b = Column::from(Series::new("a_b".into(), &["c", "y"]));
+        let df = DataFrame::new(2, vec![a, a_b]).unwrap();
+
+        let mut enc = OneHotEncoder::new();
+        let err = enc.fit(df).unwrap_err();
+        match err {
+            Error::InvalidInput(msg) => assert!(msg.contains("a_b_c"), "got: {msg}"),
+            other => panic!("expected Error::InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_one_hot_generated_vs_input_collision_errors() {
+        // Column "a" (category "b") generates "a_b", which shadows the real
+        // input column "a_b"; fit must reject it.
+        let a = Column::from(Series::new("a".into(), &["b", "c"]));
+        let a_b = Column::from(Series::new("a_b".into(), &["z", "z"]));
+        let df = DataFrame::new(2, vec![a, a_b]).unwrap();
+
+        let mut enc = OneHotEncoder::new();
+        let err = enc.fit(df).unwrap_err();
+        match err {
+            Error::InvalidInput(msg) => assert!(msg.contains("a_b"), "got: {msg}"),
+            other => panic!("expected Error::InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_one_hot_drop_first_skips_colliding_category() {
+        // With drop_first, "a"'s first category "b" (which would generate
+        // "a_b", shadowing the input column "a_b") is dropped, so fit succeeds.
+        let a = Column::from(Series::new("a".into(), &["b", "c"]));
+        let a_b = Column::from(Series::new("a_b".into(), &["z", "w"]));
+        let df = DataFrame::new(2, vec![a, a_b]).unwrap();
+
+        let mut enc = OneHotEncoder::new().drop_first(true);
+        enc.fit(df.clone()).unwrap();
+        let result = enc.transform(df).unwrap();
+        // "a" emits "a_c"; "a_b" emits "a_b_w".
+        assert_eq!(result.width(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`OneHotEncoder` names its output columns `{col}_{category}` with no collision guard. Distinct inputs can produce identical names — column `a` with category `b_c` and column `a_b` with category `c` both yield `a_b_c` — and a generated name can shadow a real input column, silently overwriting the original data. The failure is silent and layout-dependent.

Sibling transformers (`BinaryEncoder`, `DatetimeFeatures`) already reject such collisions at fit; this brings `OneHotEncoder` in line with the codebase convention.

## Change

- Factored the planned output `(column, category)` pairs into a shared `planned_pairs` helper (honoring `drop_first`) used by **both** the new fit-time guard and `transform`, so the guard validates exactly the names `transform` emits and the two can never drift.
- `fit` now seeds a `HashSet` with the input frame's column names and rejects any generated name that collides with an input column or another generated column, returning `Error::InvalidInput` that names the conflicting column and tells the user to rename it.
- Documented the policy in the `OneHotEncoder` struct docs.

## Behavior

| Input | Before | After |
| --- | --- | --- |
| columns `a`(cats `b_c`,`x`) + `a_b`(cats `c`,`y`) | silently emits two `a_b_c` columns | `fit` errors, message contains `a_b_c` |
| `a`(cat `b`) + real column `a_b` | silently overwrites `a_b` | `fit` errors, message contains `a_b` |
| normal encodes (no collision) | unchanged | unchanged |

## Test plan

- `test_one_hot_name_collision_errors`: the #138 `a`+ `b_c` vs `a_b`+ `c` collision → `Error::InvalidInput` containing `a_b_c`.
- `test_one_hot_generated_vs_input_collision_errors`: category value forming an existing input column's exact name → `fit` errors.
- `test_one_hot_drop_first_skips_colliding_category`: `drop_first` discards the colliding category so `fit` succeeds — verifies the guard honors `drop_first` exactly as `transform` does.
- Regression: `test_one_hot_encoder` (width 6) and `test_one_hot_encoder_drop_first` (width 4) unchanged.
- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --lib encoder`, `cargo test --doc encoder` all pass locally.

Closes #138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * One-hot encoding now detects conflicting generated column names and returns a clear input error instead of overwriting or misnaming columns.
  * Encoding remains consistent between fitting and transforming, including configurations that drop the first category.
  * Failed re-fitting no longer leaves stale categories available for subsequent transformations.
* **Documentation**
  * Added an unreleased changelog entry describing collision handling improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->