### PR TITLE
Fix VarianceThreshold including +/-Inf in variance computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the training features. It now returns `Error::InvalidInput` in that case, and
   a new explicit `transform_unseen` method applies the full-sample per-category
   means for genuinely new data (#135).
+- `VarianceThreshold.fit` now computes each column's variance over finite
+  values only, excluding `±Inf`. Previously a column containing a single `±Inf`
+  produced a non-finite (NaN/Inf) variance, so its mean and variance were
+  meaningless regardless of the finite values; such columns are now selected
+  (or dropped) purely on the variance of their finite values, and columns with
+  no finite values are skipped, matching the finite-values-only convention used
+  by the scalers (#148).
 
 ## [0.4.0] - 2026-08-25
 

--- a/src/feature_selection/variance_threshold.rs
+++ b/src/feature_selection/variance_threshold.rs
@@ -2,6 +2,10 @@
 //!
 //! [`VarianceThreshold`] removes features whose variance does not meet
 //! a threshold, i.e. features that are constant or nearly constant.
+//!
+//! Variance is computed over finite values only. Columns with no finite
+//! values (e.g. all-`NaN` or all-`±Inf`) are dropped from selection, matching
+//! the crate-wide finite-values-only convention used by the scalers.
 
 use crate::traits::{Error, Fit, Result, Transform};
 use polars::prelude::*;
@@ -10,6 +14,11 @@ use polars::prelude::*;
 ///
 /// Features with variance below `threshold` are removed. By default (threshold `0.0`),
 /// only constant features are removed.
+///
+/// Variance is computed over finite values only; `±Inf` and `NaN` values do not
+/// contribute to the mean/variance. A column with no finite values is dropped
+/// from the selection (it cannot have a meaningful finite variance). This matches
+/// the finite-values-only convention the crate uses elsewhere.
 ///
 /// Only `Float64` columns are considered; columns of other dtypes are silently
 /// dropped from the output.
@@ -96,7 +105,7 @@ impl Fit<DataFrame> for VarianceThreshold {
                     e
                 ))
             })?;
-            let vals: Vec<f64> = ca.iter().flatten().filter(|v| !v.is_nan()).collect();
+            let vals: Vec<f64> = ca.iter().flatten().filter(|v| v.is_finite()).collect();
             if vals.is_empty() {
                 continue;
             }
@@ -199,5 +208,51 @@ mod tests {
 
         assert_eq!(result.width(), 1);
         assert_eq!(result.get_column_names()[0].as_str(), "a");
+    }
+
+    #[test]
+    fn test_variance_threshold_inf_not_counted() {
+        // Column 'inf_const' has finite values all equal to 1.0 plus one +Inf.
+        // Column 'inf_high' has finite values with genuinely high variance plus
+        // one +Inf. Under the finite-values-only policy the variance of a column
+        // is computed over its finite values only, so:
+        //   - 'inf_const' finite variance is 0.0  -> dropped at a positive threshold
+        //   - 'inf_high'  finite variance is 20.0 -> retained
+        // A `+Inf` present in a column must not inflate (or turn into NaN) the
+        // variance of either column.
+        let inf_const = Column::from(Series::new(
+            "inf_const".into(),
+            &[1.0f64, 1.0, 1.0, 1.0, f64::INFINITY],
+        ));
+        let inf_high = Column::from(Series::new(
+            "inf_high".into(),
+            &[1.0f64, 5.0, 9.0, 13.0, f64::INFINITY],
+        ));
+        let df = DataFrame::new(5, vec![inf_const, inf_high]).unwrap();
+
+        let mut vt = VarianceThreshold::new(0.5);
+        vt.fit(df.clone()).unwrap();
+        let result = vt.transform(df).unwrap();
+
+        assert_eq!(result.width(), 1);
+        assert_eq!(result.get_column_names()[0].as_str(), "inf_high");
+    }
+
+    #[test]
+    fn test_variance_threshold_all_nonfinite_skipped() {
+        // All-Inf / all-NaN columns have no finite values and are silently
+        // skipped during fitting (no panic); a healthy finite column is still
+        // selected.
+        let inf_only = Column::from(Series::new("inf_only".into(), &[f64::INFINITY; 4]));
+        let nan_only = Column::from(Series::new("nan_only".into(), &[f64::NAN; 4]));
+        let good = Column::from(Series::new("good".into(), &[1.0f64, 5.0, 9.0, 13.0]));
+        let df = DataFrame::new(4, vec![inf_only, nan_only, good]).unwrap();
+
+        let mut vt = VarianceThreshold::new(0.5);
+        vt.fit(df.clone()).unwrap();
+        let result = vt.transform(df).unwrap();
+
+        assert_eq!(result.width(), 1);
+        assert_eq!(result.get_column_names()[0].as_str(), "good");
     }
 }


### PR DESCRIPTION
## Summary

`VarianceThreshold::fit` was filtering only NaN (not ±Inf) before computing each column's mean and variance. A column containing a single ±Inf therefore produced a non-finite (NaN/Inf) variance, so its selection was decided on meaningless math — a constant column with one ±Inf could pass any threshold, and an otherwise high-variance column could be dropped.

This changes the variance-input filter to `is_finite()` so mean/variance are computed over finite values only, matching the crate-wide finite-values-only convention used by `StandardScaler` (and Winsorizer/OutlierClipper). Columns with no finite values (all-NaN or all-±Inf) are silently skipped, consistent with the module's existing design for non-Float64 and NaN columns.

## Behavior

| Input column | Before | After |
|---|---|---|
| `[1, 1, 1, Inf]` | non-finite variance (NaN), unreliable selection | finite variance 0.0 -> dropped at a positive threshold |
| `[1, 5, 9, 13, Inf]` | non-finite variance (NaN), dropped | finite variance 20 -> retained |
| all-Inf / all-NaN | processed with garbage variance | silently skipped |

## Tests

- `test_variance_threshold_inf_not_counted`: an Inf-contaminated constant (finite values all 1.0) is dropped at a positive threshold, while an Inf-contaminated high-variance column is retained. This test fails on the old filter (fit errors because nothing meets the threshold).
- `test_variance_threshold_all_nonfinite_skipped`: all-Inf / all-NaN columns are silently skipped, no panic, and a healthy column is still selected.
- Existing `test_variance_threshold_removes_low_var`, `test_variance_threshold_zero_keeps_all`, and `test_variance_threshold_with_null_and_nan` still pass (null/NaN handling unchanged).

Note: the issue suggested threshold `0.0`, but at `0.0` a constant column (finite variance 0.0) is retained by the existing `var >= threshold` rule, so the tests use a small positive threshold (`0.5`) to make the "Inf-contaminated constant is dropped" behavior observable.

## Verification

`cargo fmt` — clean. `cargo clippy --all-targets --all-features -- -D warnings` — clean. `cargo test --lib variance_threshold` — 5/5 pass. `cargo test --doc variance_threshold` — pass.

Closes #148


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Variance-based feature selection now calculates variance using only finite values, ignoring `NaN` and infinite values.
  - Columns containing only non-finite values are skipped instead of affecting feature selection.
  - Added coverage for infinite values and entirely non-finite columns.

- **Documentation**
  - Updated guidance to clarify how non-finite values are handled during variance-based feature selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->