### PR TITLE
Add CharacterNGramVectorizer — character n-gram features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `CharacterNGramVectorizer` in `src/preprocessing/text/char_ngram_vectorizer.rs`
+  vectorizes a `String` column into character-level n-gram term counts, with a
+  `CharOnly` analyzer and a `CharWb` analyzer that keeps n-grams inside word
+  boundaries. Term selection is configurable via `ngram_range`, `min_df`,
+  `max_df` and `max_features`, with deterministic (frequency, then
+  alphabetical) vocabulary ordering (#78).
 - `ExponentiallyWeightedMovingAverage` in `src/time_series/ewma.rs` computes
   exponentially weighted moving average mean, variance, and standard deviation
   over a time series. Supports `alpha`, `span`, `com`, and `half_life`

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ let scaled = scaler.transform(data)?;
 | | `Difference` | Differencing (`x[t] - x[t-1]`) and percentage change |
 | | `DatetimeFeatures` | Extract year/month/weekday/quarter/… components from date columns |
 | | `TimeSince` | Elapsed time from a reference timestamp (`{column}_since_{unit}`) in seconds…weeks |
+| **Text** | `CharacterNGramVectorizer` | Character n-gram term-count features (char, or char-within-word-boundary) |
 | **Pipeline** | `Pipeline` | Sequentially chain multiple transformers |
 | | `ColumnTransformer` | Apply different transformers to different columns |
 | **Selection** | `VarianceThreshold` | Remove low-variance features |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,9 @@ pub mod prelude {
     pub use crate::preprocessing::scaler::RobustScaler;
     pub use crate::preprocessing::scaler::StandardScaler;
     pub use crate::preprocessing::string_cleaner::{CaseStyle, StringCleaner, StringReplacement};
+    pub use crate::preprocessing::text::char_ngram_vectorizer::{
+        Analyzer, CharacterNGramVectorizer,
+    };
     pub use crate::preprocessing::time_since::{ReferenceTime, TimeSince, TimeUnit};
     pub use crate::preprocessing::winsorizer::Winsorizer;
     pub use crate::time_series::cyclical::CyclicalEncoder;

--- a/src/preprocessing/mod.rs
+++ b/src/preprocessing/mod.rs
@@ -29,5 +29,6 @@ pub mod rare_category_grouper;
 pub mod ratio_features;
 pub mod scaler;
 pub mod string_cleaner;
+pub mod text;
 pub mod time_since;
 pub mod winsorizer;

--- a/src/preprocessing/text/char_ngram_vectorizer.rs
+++ b/src/preprocessing/text/char_ngram_vectorizer.rs
@@ -1,0 +1,831 @@
+//! Character n-gram vectorization.
+//!
+//! [`CharacterNGramVectorizer`] turns a `String` column into character-level
+//! n-gram counts. Unlike word-level vectorization, the analyzer never splits on
+//! word boundaries (unless `Analyzer::CharWb` is selected), so the features
+//! capture morphology, typo tolerance, and sub-word structure.
+
+use crate::traits::{Error, Fit, Result, Transform};
+use polars::prelude::*;
+use std::collections::HashMap;
+
+/// Which characters the n-grams are extracted from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Analyzer {
+    /// Extract n-grams over the entire string, spaces included.
+    #[default]
+    CharOnly,
+    /// Extract n-grams within word boundaries: each whitespace-separated word
+    /// is padded with a leading and trailing space and analyzed on its own, so
+    /// n-grams never span two words.
+    CharWb,
+}
+
+/// Convert a text column into character n-gram term counts.
+///
+/// `fit` learns a vocabulary of character n-grams from the configured column
+/// (`min_df`/`max_df` filter by document frequency, `max_features` then keeps
+/// the most frequent terms). `transform` counts, per document, how often each
+/// learned n-gram occurs and returns a new `DataFrame` with one `Float64`
+/// column per term, named after the n-gram itself; unknown n-grams are dropped.
+/// The input column is not carried over, so the output width equals the
+/// vocabulary size. A vocabulary that ends up empty is returned as a 0x0 frame
+/// (polars cannot represent columns-less frames with a row count).
+///
+/// Ties in the `max_features` ranking (equal corpus frequency) are broken
+/// alphabetically, so the emitted column order is deterministic across runs.
+/// `min_df == 0` and `max_features(0)` are rejected at fit time.
+///
+/// The vocabulary — and therefore the output width — grows quickly with the
+/// upper bound of `ngram_range`: the number of n-grams of a document is roughly
+/// `len * n` for a range up to `n`. Cap it with `max_features` when using wide
+/// ranges, since the output is one `Float64` column per term.
+///
+/// # Example
+///
+/// ```rust
+/// use featrs::preprocessing::text::char_ngram_vectorizer::CharacterNGramVectorizer;
+/// use featrs::traits::{Fit, Transform};
+/// use polars::prelude::{Column, DataFrame, NamedFrom, Series};
+///
+/// let col = Column::from(Series::new("text".into(), &["hello"]));
+/// let df = DataFrame::new(1, vec![col])?;
+///
+/// let mut v = CharacterNGramVectorizer::new().column("text").ngram_range(2, 2);
+/// v.fit(df.clone())?;
+/// let gram_counts = v.transform(df)?;
+///
+/// assert_eq!(gram_counts.width(), 4);
+/// let names: Vec<String> = gram_counts
+///     .get_column_names()
+///     .iter()
+///     .map(|n| n.to_string())
+///     .collect();
+/// assert_eq!(names, vec!["el", "he", "ll", "lo"]);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub struct CharacterNGramVectorizer {
+    fitted: bool,
+    column: Option<String>,
+    analyzer: Analyzer,
+    ngram_range: (usize, usize),
+    max_features: Option<usize>,
+    min_df: usize,
+    max_df: f64,
+    lowercase: bool,
+    vocabulary: Option<HashMap<String, u32>>,
+    /// Terms in vocabulary-index order (`terms[i]` is the term whose vocabulary
+    /// index is `i`), so `transform` emits columns deterministically instead of
+    /// iterating the `HashMap`.
+    terms: Vec<String>,
+}
+
+impl CharacterNGramVectorizer {
+    /// Create a new `CharacterNGramVectorizer` with default settings.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the name of the `String` column to vectorize.
+    pub fn column(mut self, c: &str) -> Self {
+        self.column = Some(c.to_string());
+        self
+    }
+
+    /// Set the analyzer (default [`Analyzer::CharOnly`]).
+    pub fn analyzer(mut self, a: Analyzer) -> Self {
+        self.analyzer = a;
+        self
+    }
+
+    /// Set the inclusive n-gram length range (default `(2, 4)`).
+    pub fn ngram_range(mut self, lo: usize, hi: usize) -> Self {
+        self.ngram_range = (lo, hi);
+        self
+    }
+
+    /// Keep at most `n` terms, ranked by corpus frequency.
+    pub fn max_features(mut self, n: usize) -> Self {
+        self.max_features = Some(n);
+        self
+    }
+
+    /// Drop terms appearing in fewer than `n` documents (default `1`).
+    pub fn min_df(mut self, n: usize) -> Self {
+        self.min_df = n;
+        self
+    }
+
+    /// Drop terms appearing in more than this fraction of documents
+    /// (default `1.0`, i.e. no upper bound).
+    pub fn max_df(mut self, p: f64) -> Self {
+        self.max_df = p;
+        self
+    }
+
+    /// Lowercase the text before extracting n-grams (default `true`).
+    pub fn lowercase(mut self, b: bool) -> Self {
+        self.lowercase = b;
+        self
+    }
+}
+
+impl Default for CharacterNGramVectorizer {
+    fn default() -> Self {
+        Self {
+            fitted: false,
+            column: None,
+            analyzer: Analyzer::CharOnly,
+            ngram_range: (2, 4),
+            max_features: None,
+            min_df: 1,
+            max_df: 1.0,
+            lowercase: true,
+            vocabulary: None,
+            terms: Vec::new(),
+        }
+    }
+}
+
+/// Push every character n-gram of length `lo..=hi` found in `chars` onto `out`.
+fn push_ngrams(chars: &[char], lo: usize, hi: usize, out: &mut Vec<String>) {
+    let len = chars.len();
+    let hi = hi.min(len);
+    // `lo..=hi` is empty when `lo > hi`, so short strings simply yield nothing.
+    for n in lo..=hi {
+        for start in 0..=(len - n) {
+            out.push(chars[start..start + n].iter().collect());
+        }
+    }
+}
+
+/// Extract every character n-gram of length `lo..=hi` from `text`.
+///
+/// `Analyzer::CharOnly` walks the whole string; `Analyzer::CharWb` pads each
+/// whitespace-separated word with a space on both sides and analyzes the words
+/// independently. Both paths are Unicode-aware: n-grams are built from
+/// `char` values (Unicode scalar values), never from UTF-8 bytes.
+fn char_ngrams(text: &str, analyzer: Analyzer, lo: usize, hi: usize) -> Vec<String> {
+    let mut out = Vec::new();
+    match analyzer {
+        Analyzer::CharOnly => {
+            let chars: Vec<char> = text.chars().collect();
+            push_ngrams(&chars, lo, hi, &mut out);
+        }
+        Analyzer::CharWb => {
+            for word in text.split_whitespace() {
+                let mut padded = Vec::with_capacity(word.chars().count() + 2);
+                padded.push(' ');
+                padded.extend(word.chars());
+                padded.push(' ');
+                push_ngrams(&padded, lo, hi, &mut out);
+            }
+        }
+    }
+    out
+}
+
+impl Fit<DataFrame> for CharacterNGramVectorizer {
+    type Output = ();
+
+    fn fit(&mut self, x: DataFrame) -> Result<()> {
+        self.fitted = false;
+        self.vocabulary = None;
+        self.terms.clear();
+
+        if x.width() == 0 || x.height() == 0 {
+            return Err(Error::InvalidInput(
+                "CharacterNGramVectorizer.fit received an empty DataFrame. \
+                 Provide at least one row and one column."
+                    .into(),
+            ));
+        }
+
+        let column = self.column.as_ref().ok_or_else(|| {
+            Error::InvalidInput(
+                "CharacterNGramVectorizer.fit: no column configured. \
+                 Call .column(\"name\") before .fit()."
+                    .into(),
+            )
+        })?;
+        let s = x
+            .column(column.as_str())
+            .map_err(|e| {
+                Error::InvalidInput(format!(
+                    "CharacterNGramVectorizer.fit: column '{}' not found. {}",
+                    column, e
+                ))
+            })?
+            .as_materialized_series();
+        let ca = s.str().map_err(|e| {
+            Error::InvalidInput(format!(
+                "CharacterNGramVectorizer.fit: column '{}' has dtype {}; expected String. {}",
+                column,
+                s.dtype(),
+                e
+            ))
+        })?;
+
+        let (lo, hi) = self.ngram_range;
+        if lo < 1 || lo > hi {
+            return Err(Error::InvalidInput(format!(
+                "CharacterNGramVectorizer: invalid ngram_range ({}, {}); \
+                 require 1 <= lower <= upper.",
+                lo, hi
+            )));
+        }
+        if self.min_df == 0 {
+            return Err(Error::InvalidInput(
+                "CharacterNGramVectorizer: min_df must be >= 1.".into(),
+            ));
+        }
+        if self.max_features == Some(0) {
+            return Err(Error::InvalidInput(
+                "CharacterNGramVectorizer: max_features must be >= 1.".into(),
+            ));
+        }
+        if !(self.max_df > 0.0 && self.max_df <= 1.0) {
+            return Err(Error::InvalidInput(format!(
+                "CharacterNGramVectorizer: max_df must be in (0.0, 1.0], got {}.",
+                self.max_df
+            )));
+        }
+
+        let n_docs = x.height() as f64;
+        let mut doc_freq: HashMap<String, u64> = HashMap::new();
+        let mut total_freq: HashMap<String, u64> = HashMap::new();
+        for doc in ca.iter() {
+            let Some(doc) = doc else { continue };
+            let text = if self.lowercase {
+                doc.to_lowercase()
+            } else {
+                doc.to_string()
+            };
+            let mut counts: HashMap<String, u64> = HashMap::new();
+            for gram in char_ngrams(&text, self.analyzer, lo, hi) {
+                *counts.entry(gram).or_insert(0) += 1;
+            }
+            for (gram, count) in counts {
+                *total_freq.entry(gram.clone()).or_insert(0) += count;
+                *doc_freq.entry(gram).or_insert(0) += 1;
+            }
+        }
+
+        let mut kept: Vec<(String, u64)> = doc_freq
+            .into_iter()
+            .filter(|(_, freq)| *freq >= self.min_df as u64 && *freq as f64 / n_docs <= self.max_df)
+            .map(|(gram, _)| {
+                let count = total_freq.get(&gram).copied().unwrap_or(0);
+                (gram, count)
+            })
+            .collect();
+        // Deterministic ranking: most frequent first, alphabetically on ties.
+        kept.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        if let Some(max) = self.max_features {
+            kept.truncate(max);
+        }
+
+        let mut vocabulary = HashMap::with_capacity(kept.len());
+        for (idx, (gram, _)) in kept.into_iter().enumerate() {
+            vocabulary.insert(gram.clone(), idx as u32);
+            self.terms.push(gram);
+        }
+        self.vocabulary = Some(vocabulary);
+        self.fitted = true;
+        Ok(())
+    }
+}
+
+impl Transform<DataFrame> for CharacterNGramVectorizer {
+    type Output = DataFrame;
+
+    fn transform(&self, x: DataFrame) -> Result<DataFrame> {
+        let not_fitted = || {
+            Error::NotFitted(
+                "CharacterNGramVectorizer has not been fitted. \
+                 Call .fit(dataframe) before .transform()."
+                    .into(),
+            )
+        };
+        if !self.fitted {
+            return Err(not_fitted());
+        }
+        let vocabulary = self.vocabulary.as_ref().ok_or_else(not_fitted)?;
+
+        let column = self.column.as_ref().ok_or_else(not_fitted)?;
+        let s = x
+            .column(column.as_str())
+            .map_err(|e| {
+                Error::InvalidInput(format!(
+                    "CharacterNGramVectorizer.transform: column '{}' not found. {}",
+                    column, e
+                ))
+            })?
+            .as_materialized_series();
+        let ca = s.str().map_err(|e| {
+            Error::InvalidInput(format!(
+                "CharacterNGramVectorizer.transform: column '{}' has dtype {}; \
+                 expected String. {}",
+                column,
+                s.dtype(),
+                e
+            ))
+        })?;
+
+        if vocabulary.is_empty() {
+            // polars ignores `height` for a frame without columns, so an empty
+            // vocabulary can only be represented by a 0x0 frame.
+            return Ok(DataFrame::empty());
+        }
+
+        let n_rows = x.height();
+        let (lo, hi) = self.ngram_range;
+        let mut counts = vec![vec![0.0f64; n_rows]; self.terms.len()];
+        for (row, doc) in ca.iter().enumerate() {
+            let Some(doc) = doc else { continue };
+            let text = if self.lowercase {
+                doc.to_lowercase()
+            } else {
+                doc.to_string()
+            };
+            for gram in char_ngrams(&text, self.analyzer, lo, hi) {
+                if let Some(idx) = vocabulary.get(gram.as_str()) {
+                    counts[*idx as usize][row] += 1.0;
+                }
+            }
+        }
+
+        let out_cols: Vec<Column> = self
+            .terms
+            .iter()
+            .enumerate()
+            .map(|(idx, term)| Column::from(Series::new(term.as_str().into(), &counts[idx])))
+            .collect();
+
+        DataFrame::new(n_rows, out_cols).map_err(|e| Error::Computation(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_df(docs: &[&str]) -> DataFrame {
+        let col = Column::from(Series::new("text".into(), docs));
+        DataFrame::new(docs.len(), vec![col]).unwrap()
+    }
+
+    /// Sum of one output column, or `0.0` if the term is not in the vocabulary.
+    fn column_sum(df: &DataFrame, name: &str) -> f64 {
+        match df.column(name) {
+            Ok(c) => c
+                .as_materialized_series()
+                .f64()
+                .unwrap()
+                .sum()
+                .unwrap_or(0.0),
+            Err(_) => 0.0,
+        }
+    }
+
+    /// `"hello"` with `(2, 3)` yields exactly the 7 expected n-grams; columns
+    /// are emitted in vocabulary-index order (frequency desc, then alphabetical).
+    #[test]
+    fn test_hello_char_only_bigrams_and_trigrams() {
+        let df = make_df(&["hello"]);
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 3);
+        v.fit(df.clone()).unwrap();
+        let out = v.transform(df).unwrap();
+
+        assert_eq!(out.width(), 7);
+        assert_eq!(out.height(), 1);
+        let names: Vec<&str> = out.get_column_names().iter().map(|n| n.as_str()).collect();
+        assert_eq!(names, vec!["el", "ell", "he", "hel", "ll", "llo", "lo"]);
+    }
+
+    /// `Analyzer::CharWb` analyzes each word on its own, padded with boundary
+    /// spaces, so no n-gram spans two words; `CharOnly` on the same input does
+    /// produce the spanning n-gram.
+    #[test]
+    fn test_char_wb_respects_word_boundaries() {
+        let df = make_df(&["hello world"]);
+        let mut wb = CharacterNGramVectorizer::new()
+            .column("text")
+            .analyzer(Analyzer::CharWb)
+            .ngram_range(2, 3);
+        wb.fit(df.clone()).unwrap();
+        let out = wb.transform(df.clone()).unwrap();
+
+        // 7 chars in " hello " and " world " each: 6 + 6 bigrams, 5 + 5 trigrams.
+        assert_eq!(out.width(), 22);
+        assert_eq!(column_sum(&out, " h"), 1.0);
+        assert_eq!(column_sum(&out, "o "), 1.0);
+        assert_eq!(column_sum(&out, " w"), 1.0);
+        assert_eq!(column_sum(&out, "d "), 1.0);
+        // The word-spanning n-gram only exists under CharOnly.
+        assert!(out.column("o w").is_err(), "CharWb must not span words");
+
+        let mut co = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 3);
+        co.fit(df.clone()).unwrap();
+        let co_out = co.transform(df).unwrap();
+        assert_eq!(column_sum(&co_out, "o w"), 1.0);
+    }
+
+    /// `min_df`/`max_df` filter by document frequency; `max_features` keeps the
+    /// most frequent terms; and the column order is deterministic, breaking
+    /// frequency ties alphabetically.
+    #[test]
+    fn test_df_filters_max_features_and_deterministic_order() {
+        // "ab" appears in 2 of 3 documents, "ac" in 1.
+        let df = make_df(&["ab", "ab", "ac"]);
+
+        let mut min_df = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 2)
+            .min_df(2);
+        min_df.fit(df.clone()).unwrap();
+        let out = min_df.transform(df.clone()).unwrap();
+        assert_eq!(out.width(), 1);
+        assert_eq!(out.get_column_names()[0].as_str(), "ab");
+
+        let mut max_df = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 2)
+            .max_df(0.5);
+        max_df.fit(df.clone()).unwrap();
+        let out = max_df.transform(df.clone()).unwrap();
+        assert_eq!(out.width(), 1);
+        assert_eq!(out.get_column_names()[0].as_str(), "ac");
+
+        // "ab" occurs twice, "ac" once, so the single kept term is the more frequent one.
+        let mut capped = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 2)
+            .max_features(1);
+        capped.fit(df.clone()).unwrap();
+        let out = capped.transform(df).unwrap();
+        assert_eq!(out.width(), 1);
+        assert_eq!(out.get_column_names()[0].as_str(), "ab");
+
+        // Equal document frequencies: the tie is broken alphabetically, and two
+        // independent fits emit the same column order.
+        let df = make_df(&["hello", "world"]);
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 2);
+        v.fit(df.clone()).unwrap();
+        let first = v.transform(df.clone()).unwrap();
+        let names: Vec<&str> = first
+            .get_column_names()
+            .iter()
+            .map(|n| n.as_str())
+            .collect();
+        assert_eq!(names, vec!["el", "he", "ld", "ll", "lo", "or", "rl", "wo"]);
+
+        let mut again = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 2);
+        again.fit(df.clone()).unwrap();
+        let second = again.transform(df).unwrap();
+        assert_eq!(
+            second.get_column_names(),
+            first.get_column_names(),
+            "column order must be deterministic across fits"
+        );
+    }
+
+    /// n-grams are built from Unicode scalar values, so a multi-byte `é` or
+    /// emoji stays a single character for n-gram purposes.
+    #[test]
+    fn test_unicode_char_ngrams() {
+        let df = make_df(&["héllo"]);
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 3);
+        v.fit(df.clone()).unwrap();
+        let out = v.transform(df).unwrap();
+
+        assert_eq!(out.width(), 7);
+        let names: Vec<&str> = out.get_column_names().iter().map(|n| n.as_str()).collect();
+        // `é` sorts after ASCII, so the `é…` terms come last.
+        assert_eq!(names, vec!["hé", "hél", "ll", "llo", "lo", "él", "éll"]);
+        assert_eq!(column_sum(&out, "hé"), 1.0);
+        assert_eq!(column_sum(&out, "hél"), 1.0);
+
+        // A 4-byte emoji is still one character.
+        let df = make_df(&["a😀b"]);
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(1, 1);
+        v.fit(df.clone()).unwrap();
+        let out = v.transform(df).unwrap();
+        assert_eq!(out.width(), 3);
+        assert_eq!(column_sum(&out, "😀"), 1.0);
+    }
+
+    /// Overlapping repeated n-grams are counted once per occurrence.
+    #[test]
+    fn test_repeated_characters_counted() {
+        let df = make_df(&["aaa"]);
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 2);
+        v.fit(df.clone()).unwrap();
+        let out = v.transform(df).unwrap();
+
+        assert_eq!(out.width(), 1);
+        assert_eq!(out.get_column_names()[0].as_str(), "aa");
+        assert_eq!(column_sum(&out, "aa"), 2.0);
+    }
+
+    /// Empty and shorter-than-`lo` documents produce all-zero rows.
+    #[test]
+    fn test_empty_and_short_documents_are_all_zero() {
+        let df = make_df(&["", "a", "hello"]);
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 3);
+        v.fit(df.clone()).unwrap();
+        let out = v.transform(df).unwrap();
+
+        assert_eq!(out.width(), 7);
+        assert_eq!(out.height(), 3);
+        for name in out.get_column_names() {
+            let ca = out
+                .column(name.as_str())
+                .unwrap()
+                .as_materialized_series()
+                .f64()
+                .unwrap();
+            assert_eq!(ca.get(0), Some(0.0), "empty document row for {name}");
+            assert_eq!(ca.get(1), Some(0.0), "one-char document row for {name}");
+        }
+        assert_eq!(column_sum(&out, "ll"), 1.0);
+    }
+
+    /// Null cells count as empty documents.
+    #[test]
+    fn test_null_documents_are_empty() {
+        let ca: StringChunked = [Some("aa"), None, Some("aa")].into_iter().collect();
+        let s = ca.into_series().with_name("text".into());
+        let df = DataFrame::new(3, vec![Column::from(s)]).unwrap();
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 2);
+        v.fit(df.clone()).unwrap();
+        let out = v.transform(df).unwrap();
+
+        assert_eq!(out.width(), 1);
+        assert_eq!(out.height(), 3);
+        let ca = out
+            .column("aa")
+            .unwrap()
+            .as_materialized_series()
+            .f64()
+            .unwrap();
+        assert_eq!(ca.get(0), Some(1.0));
+        assert_eq!(ca.get(1), Some(0.0));
+        assert_eq!(ca.get(2), Some(1.0));
+    }
+
+    /// Counts are per document, and the row count follows the input frame.
+    #[test]
+    fn test_counts_per_document_and_row_count() {
+        let df = make_df(&["aa", "aa aa", ""]);
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 2);
+        v.fit(df.clone()).unwrap();
+        let out = v.transform(df).unwrap();
+
+        assert_eq!(out.height(), 3);
+        let ca = out
+            .column("aa")
+            .unwrap()
+            .as_materialized_series()
+            .f64()
+            .unwrap();
+        assert_eq!(ca.get(0), Some(1.0));
+        assert_eq!(ca.get(1), Some(2.0));
+        assert_eq!(ca.get(2), Some(0.0));
+    }
+
+    /// Unigrams are single characters, ranked by corpus frequency.
+    #[test]
+    fn test_unigram_range_ranks_by_frequency() {
+        let df = make_df(&["abc", "cc", "", "ab"]);
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(1, 1);
+        v.fit(df.clone()).unwrap();
+        let out = v.transform(df).unwrap();
+
+        assert_eq!(out.height(), 4);
+        let names: Vec<&str> = out.get_column_names().iter().map(|n| n.as_str()).collect();
+        // "c" occurs 3 times, "a" and "b" twice each (alphabetical tie-break).
+        assert_eq!(names, vec!["c", "a", "b"]);
+        assert_eq!(column_sum(&out, "c"), 3.0);
+    }
+
+    /// n-grams absent from the vocabulary at fit time are dropped.
+    #[test]
+    fn test_unknown_ngrams_dropped() {
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 2);
+        v.fit(make_df(&["hello"])).unwrap();
+        let out = v.transform(make_df(&["xyz"])).unwrap();
+
+        assert_eq!(out.width(), 4);
+        assert_eq!(out.height(), 1);
+        for name in out.get_column_names() {
+            assert_eq!(column_sum(&out, name.as_str()), 0.0, "term {name}");
+        }
+    }
+
+    /// `lowercase(false)` keeps the text as-is, so the vocabulary is
+    /// case-sensitive; the default folds case and merges the terms.
+    #[test]
+    fn test_lowercase_option() {
+        let df = make_df(&["Hello", "hello"]);
+
+        let mut folded = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 2);
+        folded.fit(df.clone()).unwrap();
+        let out = folded.transform(df.clone()).unwrap();
+        assert_eq!(out.width(), 4);
+        assert_eq!(column_sum(&out, "ll"), 2.0);
+
+        let mut kept = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 2)
+            .lowercase(false);
+        kept.fit(df.clone()).unwrap();
+        let out = kept.transform(df).unwrap();
+        assert_eq!(out.width(), 5);
+        assert_eq!(column_sum(&out, "He"), 1.0);
+        assert_eq!(column_sum(&out, "he"), 1.0);
+        assert_eq!(column_sum(&out, "el"), 2.0);
+    }
+
+    /// `transform` before `fit` reports `NotFitted`, and a failed re-fit clears
+    /// the state learned by an earlier successful fit.
+    #[test]
+    fn test_not_fitted_and_failed_refit_resets_state() {
+        let df = make_df(&["hello"]);
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 2);
+        let err = v.transform(df.clone()).unwrap_err().to_string();
+        assert!(err.contains("not fitted"), "{err}");
+
+        v.fit(df.clone()).unwrap();
+        assert_eq!(v.transform(df.clone()).unwrap().width(), 4);
+
+        v.column = Some("missing".into());
+        assert!(v.fit(df.clone()).is_err());
+        let err = v.transform(df).unwrap_err().to_string();
+        assert!(
+            err.contains("not fitted"),
+            "stale state after failed refit: {err}"
+        );
+    }
+
+    /// An empty vocabulary (no document yields an n-gram, or every term is
+    /// filtered out) is returned as a 0x0 frame.
+    #[test]
+    fn test_empty_vocabulary_returns_empty_frame() {
+        let df = make_df(&["", "", "a"]);
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(3, 3);
+        v.fit(df.clone()).unwrap();
+        let out = v.transform(df).unwrap();
+        assert_eq!(out.width(), 0);
+        assert_eq!(out.height(), 0);
+
+        // The column is still validated even when the vocabulary is empty.
+        let other =
+            DataFrame::new(1, vec![Column::from(Series::new("other".into(), &[""]))]).unwrap();
+        assert!(
+            v.transform(other)
+                .unwrap_err()
+                .to_string()
+                .contains("not found")
+        );
+
+        // `max_df` can also filter the vocabulary down to nothing.
+        let df = make_df(&["ab", "ab"]);
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 2)
+            .max_df(0.5);
+        v.fit(df.clone()).unwrap();
+        assert_eq!(v.transform(df).unwrap().width(), 0);
+    }
+
+    /// Every invalid configuration surfaces as `Error::InvalidInput` at fit.
+    #[test]
+    fn test_fit_validation_errors() {
+        let df = make_df(&["hello"]);
+
+        let err = CharacterNGramVectorizer::new().fit(df.clone()).unwrap_err();
+        assert!(err.to_string().contains("no column configured"), "{err}");
+
+        let err = CharacterNGramVectorizer::new()
+            .column("missing")
+            .fit(df.clone())
+            .unwrap_err();
+        assert!(err.to_string().contains("not found"), "{err}");
+
+        let numeric = DataFrame::new(
+            3,
+            vec![Column::from(Series::new("text".into(), &[1i32, 2, 3]))],
+        )
+        .unwrap();
+        let err = CharacterNGramVectorizer::new()
+            .column("text")
+            .fit(numeric)
+            .unwrap_err();
+        assert!(err.to_string().contains("expected String"), "{err}");
+
+        let no_rows: StringChunked = Vec::<Option<&str>>::new().into_iter().collect();
+        let empty_rows = DataFrame::new(0, vec![Column::from(no_rows.into_series())]).unwrap();
+        let err = CharacterNGramVectorizer::new()
+            .column("text")
+            .fit(empty_rows)
+            .unwrap_err();
+        assert!(err.to_string().contains("empty DataFrame"), "{err}");
+        let err = CharacterNGramVectorizer::new()
+            .column("text")
+            .fit(DataFrame::empty())
+            .unwrap_err();
+        assert!(err.to_string().contains("empty DataFrame"), "{err}");
+
+        for (lo, hi) in [(0usize, 3usize), (3, 2)] {
+            let err = CharacterNGramVectorizer::new()
+                .column("text")
+                .ngram_range(lo, hi)
+                .fit(df.clone())
+                .unwrap_err();
+            assert!(
+                err.to_string().contains("ngram_range"),
+                "({lo}, {hi}): {err}"
+            );
+        }
+
+        let err = CharacterNGramVectorizer::new()
+            .column("text")
+            .min_df(0)
+            .fit(df.clone())
+            .unwrap_err();
+        assert!(err.to_string().contains("min_df"), "{err}");
+
+        let err = CharacterNGramVectorizer::new()
+            .column("text")
+            .max_features(0)
+            .fit(df.clone())
+            .unwrap_err();
+        assert!(err.to_string().contains("max_features"), "{err}");
+
+        for p in [0.0f64, 1.5, f64::NAN] {
+            let err = CharacterNGramVectorizer::new()
+                .column("text")
+                .max_df(p)
+                .fit(df.clone())
+                .unwrap_err();
+            assert!(err.to_string().contains("max_df"), "max_df({p}): {err}");
+        }
+    }
+
+    /// `transform` validates its own input column too.
+    #[test]
+    fn test_transform_validation_errors() {
+        let df = make_df(&["hello"]);
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 2);
+        v.fit(df).unwrap();
+
+        let err = v
+            .transform(
+                DataFrame::new(
+                    1,
+                    vec![Column::from(Series::new("other".into(), &["hello"]))],
+                )
+                .unwrap(),
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("not found"), "{err}");
+
+        let numeric =
+            DataFrame::new(1, vec![Column::from(Series::new("text".into(), &[1i32]))]).unwrap();
+        let err = v.transform(numeric).unwrap_err();
+        assert!(err.to_string().contains("expected String"), "{err}");
+    }
+}

--- a/src/preprocessing/text/char_ngram_vectorizer.rs
+++ b/src/preprocessing/text/char_ngram_vectorizer.rs
@@ -36,10 +36,21 @@ pub enum Analyzer {
 /// alphabetically, so the emitted column order is deterministic across runs.
 /// `min_df == 0` and `max_features(0)` are rejected at fit time.
 ///
+/// `char`-level runs of whitespace are collapsed to a single space under
+/// [`Analyzer::CharOnly`], as scikit-learn's `char` analyzer does, so `"a␣␣b"`
+/// and `"a␣b"` produce the same n-grams. Under [`Analyzer::CharWb`] a word
+/// shorter than the lower bound of `ngram_range` produces no n-grams at all
+/// (scikit-learn instead emits the padded word once); this keeps the guarantee
+/// that every generated term is exactly as long as its n, and matches the
+/// "text shorter than the minimum n yields an all-zero row" contract.
+///
 /// The vocabulary — and therefore the output width — grows quickly with the
-/// upper bound of `ngram_range`: the number of n-grams of a document is roughly
-/// `len * n` for a range up to `n`. Cap it with `max_features` when using wide
-/// ranges, since the output is one `Float64` column per term.
+/// upper bound of `ngram_range`: the number of distinct n-grams of a document
+/// grows roughly with the square of its length. N-grams are streamed into the
+/// counting map rather than collected per document first, but the vocabulary
+/// itself is still bounded only by the distinct substrings seen, so cap it with
+/// `max_features` when using wide ranges — the output is one `Float64` column
+/// per term.
 ///
 /// # Example
 ///
@@ -89,30 +100,35 @@ impl CharacterNGramVectorizer {
     /// Set the name of the `String` column to vectorize.
     pub fn column(mut self, c: &str) -> Self {
         self.column = Some(c.to_string());
+        self.reset();
         self
     }
 
     /// Set the analyzer (default [`Analyzer::CharOnly`]).
     pub fn analyzer(mut self, a: Analyzer) -> Self {
         self.analyzer = a;
+        self.reset();
         self
     }
 
     /// Set the inclusive n-gram length range (default `(2, 4)`).
     pub fn ngram_range(mut self, lo: usize, hi: usize) -> Self {
         self.ngram_range = (lo, hi);
+        self.reset();
         self
     }
 
-    /// Keep at most `n` terms, ranked by corpus frequency.
+    /// Keep at most `n` terms, ranked by corpus frequency (`n >= 1`).
     pub fn max_features(mut self, n: usize) -> Self {
         self.max_features = Some(n);
+        self.reset();
         self
     }
 
     /// Drop terms appearing in fewer than `n` documents (default `1`).
     pub fn min_df(mut self, n: usize) -> Self {
         self.min_df = n;
+        self.reset();
         self
     }
 
@@ -120,13 +136,26 @@ impl CharacterNGramVectorizer {
     /// (default `1.0`, i.e. no upper bound).
     pub fn max_df(mut self, p: f64) -> Self {
         self.max_df = p;
+        self.reset();
         self
     }
 
     /// Lowercase the text before extracting n-grams (default `true`).
     pub fn lowercase(mut self, b: bool) -> Self {
         self.lowercase = b;
+        self.reset();
         self
+    }
+
+    /// Discard the learned vocabulary.
+    ///
+    /// Every configuration change invalidates the vocabulary it was learned
+    /// from, so a setter called after `fit` cannot leave `transform` applying a
+    /// stale vocabulary to the new configuration.
+    fn reset(&mut self) {
+        self.fitted = false;
+        self.vocabulary = None;
+        self.terms.clear();
     }
 }
 
@@ -147,30 +176,61 @@ impl Default for CharacterNGramVectorizer {
     }
 }
 
-/// Push every character n-gram of length `lo..=hi` found in `chars` onto `out`.
-fn push_ngrams(chars: &[char], lo: usize, hi: usize, out: &mut Vec<String>) {
+/// Collapse each run of two or more whitespace characters into a single space.
+///
+/// This mirrors the whitespace normalization scikit-learn's `char` analyzer
+/// applies before slicing n-grams; a lone whitespace character is left as-is.
+/// `Analyzer::CharWb` needs no normalization because splitting on whitespace
+/// already discards the difference between one and several separators.
+fn collapse_whitespace_runs(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch.is_whitespace() && chars.peek().is_some_and(|next| next.is_whitespace()) {
+            out.push(' ');
+            while chars.peek().is_some_and(|next| next.is_whitespace()) {
+                chars.next();
+            }
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Call `f` with every character n-gram of length `lo..=hi` found in `chars`.
+///
+/// N-grams are passed as slices so callers can count or look them up without
+/// materializing a `String` per occurrence.
+fn for_each_ngram(chars: &[char], lo: usize, hi: usize, mut f: impl FnMut(&[char])) {
     let len = chars.len();
     let hi = hi.min(len);
     // `lo..=hi` is empty when `lo > hi`, so short strings simply yield nothing.
     for n in lo..=hi {
         for start in 0..=(len - n) {
-            out.push(chars[start..start + n].iter().collect());
+            f(&chars[start..start + n]);
         }
     }
 }
 
-/// Extract every character n-gram of length `lo..=hi` from `text`.
+/// Feed every character n-gram of length `lo..=hi` in `text` to `f`.
 ///
 /// `Analyzer::CharOnly` walks the whole string; `Analyzer::CharWb` pads each
 /// whitespace-separated word with a space on both sides and analyzes the words
-/// independently. Both paths are Unicode-aware: n-grams are built from
-/// `char` values (Unicode scalar values), never from UTF-8 bytes.
-fn char_ngrams(text: &str, analyzer: Analyzer, lo: usize, hi: usize) -> Vec<String> {
-    let mut out = Vec::new();
+/// independently, so no n-gram spans two words. Both paths are Unicode-aware:
+/// n-grams are built from `char` scalar values, never from UTF-8 bytes.
+fn for_each_ngram_in_text(
+    text: &str,
+    analyzer: Analyzer,
+    lo: usize,
+    hi: usize,
+    mut f: impl FnMut(&[char]),
+) {
     match analyzer {
         Analyzer::CharOnly => {
-            let chars: Vec<char> = text.chars().collect();
-            push_ngrams(&chars, lo, hi, &mut out);
+            let normalized = collapse_whitespace_runs(text);
+            let chars: Vec<char> = normalized.chars().collect();
+            for_each_ngram(&chars, lo, hi, f);
         }
         Analyzer::CharWb => {
             for word in text.split_whitespace() {
@@ -178,20 +238,18 @@ fn char_ngrams(text: &str, analyzer: Analyzer, lo: usize, hi: usize) -> Vec<Stri
                 padded.push(' ');
                 padded.extend(word.chars());
                 padded.push(' ');
-                push_ngrams(&padded, lo, hi, &mut out);
+                for_each_ngram(&padded, lo, hi, &mut f);
             }
         }
     }
-    out
 }
 
 impl Fit<DataFrame> for CharacterNGramVectorizer {
     type Output = ();
 
     fn fit(&mut self, x: DataFrame) -> Result<()> {
-        self.fitted = false;
-        self.vocabulary = None;
-        self.terms.clear();
+        // Reset state first so a failed re-fit cannot leave stale state.
+        self.reset();
 
         if x.width() == 0 || x.height() == 0 {
             return Err(Error::InvalidInput(
@@ -252,8 +310,8 @@ impl Fit<DataFrame> for CharacterNGramVectorizer {
         }
 
         let n_docs = x.height() as f64;
-        let mut doc_freq: HashMap<String, u64> = HashMap::new();
-        let mut total_freq: HashMap<String, u64> = HashMap::new();
+        let mut doc_freq: HashMap<Vec<char>, u64> = HashMap::new();
+        let mut total_freq: HashMap<Vec<char>, u64> = HashMap::new();
         for doc in ca.iter() {
             let Some(doc) = doc else { continue };
             let text = if self.lowercase {
@@ -261,17 +319,22 @@ impl Fit<DataFrame> for CharacterNGramVectorizer {
             } else {
                 doc.to_string()
             };
-            let mut counts: HashMap<String, u64> = HashMap::new();
-            for gram in char_ngrams(&text, self.analyzer, lo, hi) {
-                *counts.entry(gram).or_insert(0) += 1;
-            }
+            let mut counts: HashMap<Vec<char>, u64> = HashMap::new();
+            for_each_ngram_in_text(&text, self.analyzer, lo, hi, |gram| {
+                match counts.get_mut(gram) {
+                    Some(count) => *count += 1,
+                    None => {
+                        counts.insert(gram.to_vec(), 1);
+                    }
+                }
+            });
             for (gram, count) in counts {
                 *total_freq.entry(gram.clone()).or_insert(0) += count;
                 *doc_freq.entry(gram).or_insert(0) += 1;
             }
         }
 
-        let mut kept: Vec<(String, u64)> = doc_freq
+        let mut kept: Vec<(Vec<char>, u64)> = doc_freq
             .into_iter()
             .filter(|(_, freq)| *freq >= self.min_df as u64 && *freq as f64 / n_docs <= self.max_df)
             .map(|(gram, _)| {
@@ -287,8 +350,9 @@ impl Fit<DataFrame> for CharacterNGramVectorizer {
 
         let mut vocabulary = HashMap::with_capacity(kept.len());
         for (idx, (gram, _)) in kept.into_iter().enumerate() {
-            vocabulary.insert(gram.clone(), idx as u32);
-            self.terms.push(gram);
+            let term: String = gram.iter().collect();
+            vocabulary.insert(term.clone(), idx as u32);
+            self.terms.push(term);
         }
         self.vocabulary = Some(vocabulary);
         self.fitted = true;
@@ -340,6 +404,12 @@ impl Transform<DataFrame> for CharacterNGramVectorizer {
 
         let n_rows = x.height();
         let (lo, hi) = self.ngram_range;
+        // Look terms up by character slice so counting allocates nothing per
+        // occurrence (only once per vocabulary entry, here).
+        let lookup: HashMap<Vec<char>, u32> = vocabulary
+            .iter()
+            .map(|(term, idx)| (term.chars().collect(), *idx))
+            .collect();
         let mut counts = vec![vec![0.0f64; n_rows]; self.terms.len()];
         for (row, doc) in ca.iter().enumerate() {
             let Some(doc) = doc else { continue };
@@ -348,11 +418,11 @@ impl Transform<DataFrame> for CharacterNGramVectorizer {
             } else {
                 doc.to_string()
             };
-            for gram in char_ngrams(&text, self.analyzer, lo, hi) {
-                if let Some(idx) = vocabulary.get(gram.as_str()) {
+            for_each_ngram_in_text(&text, self.analyzer, lo, hi, |gram| {
+                if let Some(idx) = lookup.get(gram) {
                     counts[*idx as usize][row] += 1.0;
                 }
-            }
+            });
         }
 
         let out_cols: Vec<Column> = self
@@ -827,5 +897,66 @@ mod tests {
             DataFrame::new(1, vec![Column::from(Series::new("text".into(), &[1i32]))]).unwrap();
         let err = v.transform(numeric).unwrap_err();
         assert!(err.to_string().contains("expected String"), "{err}");
+    }
+
+    /// `CharOnly` collapses runs of whitespace into one space, so repeated
+    /// separators do not add terms; a lone whitespace character is kept as-is.
+    #[test]
+    fn test_char_only_collapses_whitespace_runs() {
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 3);
+        v.fit(make_df(&["a  b"])).unwrap();
+        let out = v.transform(make_df(&["a  b"])).unwrap();
+        let names: Vec<&str> = out.get_column_names().iter().map(|n| n.as_str()).collect();
+        assert_eq!(names, vec![" b", "a ", "a b"]);
+        assert_eq!(column_sum(&out, "a "), 1.0);
+
+        // A run of any whitespace characters collapses the same way.
+        let out = v.transform(make_df(&["a\t\nb"])).unwrap();
+        let names: Vec<&str> = out.get_column_names().iter().map(|n| n.as_str()).collect();
+        assert_eq!(names, vec![" b", "a ", "a b"]);
+
+        // A single whitespace character is not a run and is preserved.
+        let mut single = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 2);
+        single.fit(make_df(&["a\tb"])).unwrap();
+        let out = single.transform(make_df(&["a\tb"])).unwrap();
+        assert_eq!(out.width(), 2);
+        assert_eq!(column_sum(&out, "a\t"), 1.0);
+    }
+
+    /// Under `CharWb` a word shorter than the lower n-gram bound contributes no
+    /// terms, so every emitted term has a length inside `ngram_range`.
+    #[test]
+    fn test_char_wb_short_word_yields_no_terms() {
+        let df = make_df(&["i am here"]);
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .analyzer(Analyzer::CharWb)
+            .ngram_range(5, 5);
+        v.fit(df.clone()).unwrap();
+        let out = v.transform(df).unwrap();
+
+        // " i " (3 chars) and " am " (4 chars) are too short for a 5-gram; only
+        // " here " (6 chars) is long enough: " here" and "here ".
+        let names: Vec<&str> = out.get_column_names().iter().map(|n| n.as_str()).collect();
+        assert_eq!(names, vec![" here", "here "]);
+    }
+
+    /// Changing any configuration invalidates the learned vocabulary.
+    #[test]
+    fn test_setter_invalidates_fitted_state() {
+        let df = make_df(&["hello"]);
+        let mut v = CharacterNGramVectorizer::new()
+            .column("text")
+            .ngram_range(2, 2);
+        v.fit(df.clone()).unwrap();
+        assert_eq!(v.transform(df.clone()).unwrap().width(), 4);
+
+        let v = v.ngram_range(2, 3);
+        let err = v.transform(df).unwrap_err().to_string();
+        assert!(err.contains("not fitted"), "{err}");
     }
 }

--- a/src/preprocessing/text/char_ngram_vectorizer.rs
+++ b/src/preprocessing/text/char_ngram_vectorizer.rs
@@ -7,6 +7,7 @@
 
 use crate::traits::{Error, Fit, Result, Transform};
 use polars::prelude::*;
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 /// Which characters the n-grams are extracted from.
@@ -27,10 +28,14 @@ pub enum Analyzer {
 /// (`min_df`/`max_df` filter by document frequency, `max_features` then keeps
 /// the most frequent terms). `transform` counts, per document, how often each
 /// learned n-gram occurs and returns a new `DataFrame` with one `Float64`
-/// column per term, named after the n-gram itself; unknown n-grams are dropped.
-/// The input column is not carried over, so the output width equals the
-/// vocabulary size. A vocabulary that ends up empty is returned as a 0x0 frame
-/// (polars cannot represent columns-less frames with a row count).
+/// column per term, named after the n-gram itself — a term can be whitespace
+/// only, e.g. `" "` under `ngram_range(1, 1)`. Unknown n-grams are dropped. The
+/// input column is not carried over, so the output width equals the vocabulary
+/// size. A vocabulary that ends up empty is returned as a 0x0 frame (polars
+/// cannot represent columns-less frames with a row count), so a downstream
+/// pipeline step receives an empty frame rather than one row per document.
+/// `null` cells contribute no n-grams but still count as documents for the
+/// `min_df`/`max_df` denominators.
 ///
 /// Ties in the `max_features` ranking (equal corpus frequency) are broken
 /// alphabetically, so the emitted column order is deterministic across runs.
@@ -38,11 +43,13 @@ pub enum Analyzer {
 ///
 /// `char`-level runs of whitespace are collapsed to a single space under
 /// [`Analyzer::CharOnly`], as scikit-learn's `char` analyzer does, so `"a␣␣b"`
-/// and `"a␣b"` produce the same n-grams. Under [`Analyzer::CharWb`] a word
-/// shorter than the lower bound of `ngram_range` produces no n-grams at all
-/// (scikit-learn instead emits the padded word once); this keeps the guarantee
-/// that every generated term is exactly as long as its n, and matches the
-/// "text shorter than the minimum n yields an all-zero row" contract.
+/// and `"a␣b"` produce the same n-grams. Under [`Analyzer::CharWb`] a word whose
+/// padded length — its character count plus the two boundary spaces — is below
+/// the lower bound of `ngram_range` produces no n-grams at all (scikit-learn
+/// instead emits the padded word once); this keeps the guarantee that every
+/// generated term is exactly as long as its n, and matches the "text shorter
+/// than the minimum n yields an all-zero row" contract. Note that a one-word
+/// document is therefore measured with its two padding spaces.
 ///
 /// The vocabulary — and therefore the output width — grows quickly with the
 /// upper bound of `ngram_range`: the number of distinct n-grams of a document
@@ -310,14 +317,14 @@ impl Fit<DataFrame> for CharacterNGramVectorizer {
         }
 
         let n_docs = x.height() as f64;
-        let mut doc_freq: HashMap<Vec<char>, u64> = HashMap::new();
-        let mut total_freq: HashMap<Vec<char>, u64> = HashMap::new();
+        // One entry per distinct n-gram: (document frequency, total occurrences).
+        let mut stats: HashMap<Vec<char>, (u64, u64)> = HashMap::new();
         for doc in ca.iter() {
             let Some(doc) = doc else { continue };
-            let text = if self.lowercase {
-                doc.to_lowercase()
+            let text: Cow<str> = if self.lowercase {
+                Cow::Owned(doc.to_lowercase())
             } else {
-                doc.to_string()
+                Cow::Borrowed(doc)
             };
             let mut counts: HashMap<Vec<char>, u64> = HashMap::new();
             for_each_ngram_in_text(&text, self.analyzer, lo, hi, |gram| {
@@ -329,18 +336,18 @@ impl Fit<DataFrame> for CharacterNGramVectorizer {
                 }
             });
             for (gram, count) in counts {
-                *total_freq.entry(gram.clone()).or_insert(0) += count;
-                *doc_freq.entry(gram).or_insert(0) += 1;
+                let entry = stats.entry(gram).or_insert((0, 0));
+                entry.0 += 1;
+                entry.1 += count;
             }
         }
 
-        let mut kept: Vec<(Vec<char>, u64)> = doc_freq
+        let mut kept: Vec<(Vec<char>, u64)> = stats
             .into_iter()
-            .filter(|(_, freq)| *freq >= self.min_df as u64 && *freq as f64 / n_docs <= self.max_df)
-            .map(|(gram, _)| {
-                let count = total_freq.get(&gram).copied().unwrap_or(0);
-                (gram, count)
+            .filter(|(_, (doc_freq, _))| {
+                *doc_freq >= self.min_df as u64 && *doc_freq as f64 / n_docs <= self.max_df
             })
+            .map(|(gram, (_, total_freq))| (gram, total_freq))
             .collect();
         // Deterministic ranking: most frequent first, alphabetically on ties.
         kept.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
@@ -363,6 +370,12 @@ impl Fit<DataFrame> for CharacterNGramVectorizer {
 impl Transform<DataFrame> for CharacterNGramVectorizer {
     type Output = DataFrame;
 
+    /// Count the fitted vocabulary's n-grams per document.
+    ///
+    /// Returns a frame of `Float64` counts (one column per term, one row per
+    /// document). When the vocabulary is empty the result is a 0x0 frame, since
+    /// polars drops the height of a frame without columns — downstream steps
+    /// receive an empty frame rather than one row per document.
     fn transform(&self, x: DataFrame) -> Result<DataFrame> {
         let not_fitted = || {
             Error::NotFitted(
@@ -413,10 +426,10 @@ impl Transform<DataFrame> for CharacterNGramVectorizer {
         let mut counts = vec![vec![0.0f64; n_rows]; self.terms.len()];
         for (row, doc) in ca.iter().enumerate() {
             let Some(doc) = doc else { continue };
-            let text = if self.lowercase {
-                doc.to_lowercase()
+            let text: Cow<str> = if self.lowercase {
+                Cow::Owned(doc.to_lowercase())
             } else {
-                doc.to_string()
+                Cow::Borrowed(doc)
             };
             for_each_ngram_in_text(&text, self.analyzer, lo, hi, |gram| {
                 if let Some(idx) = lookup.get(gram) {

--- a/src/preprocessing/text/mod.rs
+++ b/src/preprocessing/text/mod.rs
@@ -1,0 +1,12 @@
+//! Text feature extraction.
+//!
+//! Transformers in this module convert `String` columns into numeric feature
+//! matrices. They follow the crate's usual contract: `fit` learns a vocabulary
+//! from a text column of the training frame, and `transform` emits a new
+//! `DataFrame` holding one column per learned term (the input text column is
+//! not carried over). Terms that were not seen during `fit` are dropped.
+//!
+//! [`char_ngram_vectorizer::CharacterNGramVectorizer`] extracts overlapping
+//! character n-grams, which capture sub-word structure and are robust to typos.
+
+pub mod char_ngram_vectorizer;


### PR DESCRIPTION
## Summary

Adds `CharacterNGramVectorizer` to the new `src/preprocessing/text/` module: it turns a `String` column into character-level n-gram term counts, the character-level counterpart to word-boundary vectorization. Character n-grams capture morphology and sub-word structure and are robust to typos, which makes them useful for language identification, authorship attribution, and text classification where out-of-vocabulary handling matters.

It follows scikit-learn's `CountVectorizer(analyzer="char")` / `analyzer="char_wb"`.

## API

```rust
pub enum Analyzer { CharOnly, CharWb }

let mut v = CharacterNGramVectorizer::new()
    .column("text")
    .analyzer(Analyzer::CharOnly)   // default
    .ngram_range(2, 4)              // default
    .max_features(1000)             // default: no cap
    .min_df(1)                      // default: 1
    .max_df(1.0)                    // default: no cap
    .lowercase(true);               // default: true
v.fit(df.clone())?;
let grams = v.transform(df)?;       // one Float64 column per learned n-gram
```

Following the crate's existing text-to-matrix precedent (`FeatureHasher`), `transform` returns a **new** frame containing only the generated vocabulary columns; the input text column is not carried over, so the output width equals the vocabulary size.

## `CharOnly` vs `CharWb`

| Analyzer | `"hello world"`, `ngram_range(2, 2)` | Notes |
|---|---|---|
| `CharOnly` | `he el ll lo o␣ ␣w wo or rl ld` | n-grams over the whole string; can span two words |
| `CharWb` | `" hello "` and `" world "` analysed separately | each word is padded with boundary spaces, so no n-gram spans words (`o w` is absent); produces terms like `"␣h"`, `"o␣"`, `"␣wo"` |

Both analyzers build n-grams from `char` scalar values rather than UTF-8 bytes, so `"héllo"` yields `"hé"` as a single term and a 4-byte emoji counts as one character.

## Behaviour and decisions

- **Vocabulary ordering is deterministic.** Terms are ranked by corpus frequency and truncated by `max_features`, with alphabetical tie-breaking, and vocabulary indices are assigned in that order. `transform` emits columns in index order rather than iterating the `HashMap`, so two fits on the same input produce identical column order.
- **Validation happens in `fit`** (builders return `Self` and cannot fail): empty frame, unset/missing/non-`String` column (message includes the actual dtype), `ngram_range` outside `1 <= lo <= hi`, `min_df == 0`, `max_features(0)`, and `max_df` outside `(0.0, 1.0]` all return `Error::InvalidInput`. `fit` clears learned state first — and so does every builder, so reconfiguring a fitted vectorizer cannot leave a stale vocabulary in place — while `transform` before fit returns `Error::NotFitted`.
- **Edge cases:** empty string and strings shorter than the minimum n produce all-zero rows; null cells are treated as empty documents; n-grams unseen at fit time are dropped; repeated n-grams are counted once per occurrence (`"aaa"` with `(2, 2)` gives `"aa" == 2`).
- **Whitespace:** `CharOnly` collapses runs of whitespace into a single space before slicing, matching scikit-learn's `char` analyzer, so `"a␣␣b"` and `"a␣b"` produce the same terms. `CharWb` splits on whitespace, so it already ignores the distinction.
- **Deliberate deviation from scikit-learn, please veto if you disagree:** under `CharWb`, a word whose padded length (its character count plus the two boundary spaces) is below the lower bound of `ngram_range` contributes no terms, whereas scikit-learn's `_char_wb_ngrams` emits the padded word once (a term shorter than `n`). I kept the stricter behaviour because the issue states that text shorter than the minimum n must yield an all-zero row, and it preserves the invariant that every generated term is exactly as long as its n. It is documented on the struct and covered by a test.
- **Empty vocabulary** (every document empty, or every term filtered out) yields an empty frame. Note the caveat: polars ignores `height` for a frame with no columns, so that path necessarily returns a 0x0 frame — documented on the struct.
- **Memory:** the vocabulary (and therefore the output width) grows with the number of distinct substrings, so `max_features` is the intended cap and the cost is documented on the struct. N-grams are streamed into the counting map as character slices instead of being collected per document first, so counting allocates only when a term is seen for the first time.

## Test plan

- 18 unit tests in `#[cfg(test)] mod tests` covering the issue's cases: `"hello"` with `(2, 3)` (7 terms), `CharWb` word boundaries on `"hello world"`, short words under `CharWb`, Unicode (`"héllo"`, emoji unigrams), repeated characters, unigrams, empty/short/null documents, unknown n-grams at transform time, `lowercase(false)`, `min_df`/`max_df`/`max_features`, deterministic column order across fits, whitespace-run collapsing, empty vocabulary, transform-before-fit, builder invalidation and failed-refit state reset, and every validation error path.
- One runnable doctest on the struct.
- `cargo clippy --all-targets --all-features -- -D warnings` clean, `rustfmt --edition 2024` clean, `cargo doc` with `-D warnings` clean, and `cargo test --lib char_ngram_vectorizer` + `cargo test --doc char_ngram_vectorizer` green.
- No new dependencies; `Cargo.toml`/`Cargo.lock` untouched.

Closes #78
